### PR TITLE
fix(admin): allow editing any opportunity from admin portal

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -16,6 +16,7 @@
 - ✅ **`/client/gigs` (Manage opportunities):** Card **Edit** is wired to **`/client/gigs/[id]/edit`**; non-functional placeholder **Edit** / **Delete** row removed (single row: View \| Edit \| Applications).
 - ✅ **Applications:** Non-blocking warning when the opportunity already has applications (applicants may have relied on prior details).
 - ✅ **Lock:** Editing unavailable when any related booking is **`completed`** (blocked in UI + server action).
+- ✅ **Admin — All Opportunities:** **`/admin/gigs/[id]/edit`** with **`updateGigAsAdminAction`** (explicit **`profiles.role === admin`** + RLS); ⋮ menu and opportunity detail **Edit**; completed-booking **warning** only (admin may still save). **`PostGigClient`** supports `surface="admin"` vs Career Builder.
 - ✅ **Deferred:** Cover image is not editable in this pass (post/create flow unchanged).
 
 **Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — all green.

--- a/app/admin/gigs/[id]/admin-gig-detail-client.tsx
+++ b/app/admin/gigs/[id]/admin-gig-detail-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { User } from "@supabase/supabase-js";
-import { ArrowLeft, Eye, MapPin, Calendar, DollarSign, Building2, Users } from "lucide-react";
+import { ArrowLeft, Eye, MapPin, Calendar, DollarSign, Building2, Pencil, Users } from "lucide-react";
 import Link from "next/link";
 
 import { PageHeader } from "@/components/layout/page-header";
@@ -83,12 +83,20 @@ export function AdminGigDetailClient({
           title={gig.title}
           subtitle="Opportunity details and applicant activity"
           actions={
-            <Button asChild variant="outline" className="border-gray-700 text-white hover:bg-gray-800">
-              <Link href={`/gigs/${gig.id}`}>
-                <Eye className="h-4 w-4 mr-2" />
-                View public page
-              </Link>
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button asChild className="bg-purple-600 text-white hover:bg-purple-700">
+                <Link href={`/admin/gigs/${gig.id}/edit`}>
+                  <Pencil className="h-4 w-4 mr-2" />
+                  Edit
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="border-gray-700 text-white hover:bg-gray-800">
+                <Link href={`/gigs/${gig.id}`}>
+                  <Eye className="h-4 w-4 mr-2" />
+                  View public page
+                </Link>
+              </Button>
+            </div>
           }
         />
 

--- a/app/admin/gigs/[id]/edit/page.tsx
+++ b/app/admin/gigs/[id]/edit/page.tsx
@@ -1,0 +1,96 @@
+import { notFound, redirect } from "next/navigation";
+
+import { PostGigClient } from "@/app/post-gig/post-gig-client";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { createSupabaseServer } from "@/lib/supabase/supabase-server";
+import { logger } from "@/lib/utils/logger";
+import { type ProfileRow } from "@/types/database-helpers";
+
+export const dynamic = "force-dynamic";
+
+function formatDateForDateInput(date: string): string {
+  if (!date) return "";
+  return date.length >= 10 ? date.slice(0, 10) : date;
+}
+
+function formatDeadlineForDatetimeLocal(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+interface AdminEditGigPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function AdminEditGigPage({ params }: AdminEditGigPageProps) {
+  const { id: gigId } = await params;
+  const supabase = await createSupabaseServer();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    redirect(`/login?returnUrl=${encodeURIComponent(`/admin/gigs/${gigId}/edit`)}`);
+  }
+
+  const { data: userData, error: userError } = await supabase.from("profiles").select("role").eq("id", user.id).single();
+
+  if (userError || (userData as ProfileRow)?.role !== "admin") {
+    redirect(`/login?returnUrl=${encodeURIComponent(`/admin/gigs/${gigId}/edit`)}`);
+  }
+
+  const [{ data: gig, error: gigError }, applicationsCountResult, { data: completedBooking }] = await Promise.all([
+    supabase
+      .from("gigs")
+      .select(
+        "id,client_id,title,description,category,location,compensation,duration,date,application_deadline,status"
+      )
+      .eq("id", gigId)
+      .maybeSingle(),
+    supabase.from("applications").select("id", { count: "exact", head: true }).eq("gig_id", gigId),
+    supabase.from("bookings").select("id").eq("gig_id", gigId).eq("status", "completed").limit(1).maybeSingle(),
+  ]);
+
+  if (gigError) {
+    logger.error("[admin/gigs/edit] gig fetch error", gigError, { gigId });
+    notFound();
+  }
+
+  if (!gig) {
+    notFound();
+  }
+
+  const applicationsCount = applicationsCountResult.count ?? 0;
+  const hasApplications = applicationsCount > 0;
+  const hasCompletedBookings = Boolean(completedBooking);
+
+  const initialValues = {
+    title: gig.title,
+    description: gig.description,
+    category: gig.category,
+    location: gig.location,
+    compensation: gig.compensation,
+    duration: gig.duration,
+    date: formatDateForDateInput(gig.date),
+    application_deadline: formatDeadlineForDatetimeLocal(gig.application_deadline),
+  };
+
+  return (
+    <>
+      <AdminHeader user={user} />
+      <PostGigClient
+        mode="edit"
+        gigId={gigId}
+        surface="admin"
+        initialValues={initialValues}
+        hasApplications={hasApplications}
+        hasCompletedBookings={hasCompletedBookings}
+      />
+    </>
+  );
+}

--- a/app/admin/gigs/admin-gigs-client.tsx
+++ b/app/admin/gigs/admin-gigs-client.tsx
@@ -7,6 +7,7 @@ import {
   Briefcase,
   MapPin,
   Eye,
+  Pencil,
   Plus,
   SlidersHorizontal,
   Calendar,
@@ -145,6 +146,13 @@ export function AdminGigsClient({ gigs: initialGigs, user }: AdminGigsClientProp
                   >
                     <Link href={`/admin/gigs/${gig.id}`}>View details</Link>
                   </Button>
+                  <Button
+                    asChild
+                    size="sm"
+                    className="h-9 bg-purple-600 text-white hover:bg-purple-700"
+                  >
+                    <Link href={`/admin/gigs/${gig.id}/edit`}>Edit</Link>
+                  </Button>
                 </div>
               }
               trailing={
@@ -164,6 +172,15 @@ export function AdminGigsClient({ gigs: initialGigs, user }: AdminGigsClientProp
                       <Link href={`/admin/gigs/${gig.id}`} className="text-gray-300 hover:bg-gray-700 flex items-center">
                         <Eye className="mr-2 h-4 w-4" />
                         View Opportunity
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link
+                        href={`/admin/gigs/${gig.id}/edit`}
+                        className="text-gray-300 hover:bg-gray-700 flex items-center"
+                      >
+                        <Pencil className="mr-2 h-4 w-4" />
+                        Edit Opportunity
                       </Link>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
@@ -240,6 +257,15 @@ export function AdminGigsClient({ gigs: initialGigs, user }: AdminGigsClientProp
                           <Link href={`/admin/gigs/${gig.id}`} className="text-gray-300 hover:bg-gray-700 flex items-center">
                             <Eye className="mr-2 h-4 w-4" />
                             View Opportunity
+                          </Link>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem asChild>
+                          <Link
+                            href={`/admin/gigs/${gig.id}/edit`}
+                            className="text-gray-300 hover:bg-gray-700 flex items-center"
+                          >
+                            <Pencil className="mr-2 h-4 w-4" />
+                            Edit Opportunity
                           </Link>
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/app/admin/gigs/edit-actions.ts
+++ b/app/admin/gigs/edit-actions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { createSupabaseServer } from "@/lib/supabase/supabase-server";
+import { logger } from "@/lib/utils/logger";
+import type { Database } from "@/types/supabase";
+
+type GigUpdate = Database["public"]["Tables"]["gigs"]["Update"];
+
+export async function updateGigAsAdminAction(input: {
+  gigId: string;
+  title: string;
+  description: string;
+  category: string;
+  location: string;
+  compensation: string;
+  duration: string;
+  date: string;
+  application_deadline?: string | null;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const supabase = await createSupabaseServer();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return { ok: false, error: "Not authenticated" };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    logger.error("[updateGigAsAdminAction] profile lookup failed", profileError);
+    return { ok: false, error: "Unable to verify permissions." };
+  }
+
+  if (!profile || profile.role !== "admin") {
+    return { ok: false, error: "Not allowed" };
+  }
+
+  const { data: gigRow, error: gigFetchError } = await supabase
+    .from("gigs")
+    .select("id")
+    .eq("id", input.gigId)
+    .maybeSingle();
+
+  if (gigFetchError || !gigRow) {
+    return { ok: false, error: "Opportunity not found" };
+  }
+
+  const updatePayload: Pick<
+    GigUpdate,
+    "title" | "description" | "category" | "location" | "compensation" | "duration" | "date" | "application_deadline"
+  > = {
+    title: input.title,
+    description: input.description,
+    category: input.category,
+    location: input.location,
+    compensation: input.compensation,
+    duration: input.duration,
+    date: input.date,
+    application_deadline: input.application_deadline?.trim()
+      ? input.application_deadline.trim()
+      : null,
+  };
+
+  const { error: gigUpdateError } = await supabase.from("gigs").update(updatePayload).eq("id", input.gigId);
+
+  if (gigUpdateError) {
+    logger.error("[updateGigAsAdminAction] update failed", gigUpdateError);
+    return { ok: false, error: gigUpdateError.message ?? "Failed to update opportunity" };
+  }
+
+  revalidatePath("/admin/gigs");
+  revalidatePath(`/admin/gigs/${input.gigId}`);
+  revalidatePath("/client/dashboard");
+  revalidatePath("/client/gigs");
+  revalidatePath("/gigs");
+  revalidatePath(`/gigs/${input.gigId}`);
+
+  return { ok: true };
+}

--- a/app/post-gig/post-gig-client.tsx
+++ b/app/post-gig/post-gig-client.tsx
@@ -9,6 +9,7 @@ import type React from "react";
 import { useState } from "react";
 
 import { createGigAction, updateGigAction } from "./actions";
+import { updateGigAsAdminAction } from "@/app/admin/gigs/edit-actions";
 import { useAuth } from "@/components/auth/auth-provider";
 import { GigImageUploader } from "@/components/gigs/gig-image-uploader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -41,8 +42,12 @@ const emptyForm = {
 export type PostGigClientProps = {
   mode?: "create" | "edit";
   gigId?: string;
+  /** Career Builder (default) vs platform admin edit surface */
+  surface?: "client" | "admin";
   initialValues?: typeof emptyForm;
   hasApplications?: boolean;
+  /** Admin only: at least one completed booking exists (informational warning; save still allowed) */
+  hasCompletedBookings?: boolean;
   editLocked?: boolean;
   editLockedReason?: string;
 };
@@ -50,8 +55,10 @@ export type PostGigClientProps = {
 export function PostGigClient({
   mode = "create",
   gigId,
+  surface = "client",
   initialValues,
   hasApplications = false,
+  hasCompletedBookings = false,
   editLocked = false,
   editLockedReason,
 }: PostGigClientProps = {}) {
@@ -63,6 +70,10 @@ export function PostGigClient({
 
   const [formData, setFormData] = useState(() => initialValues ?? emptyForm);
   const [imageFile, setImageFile] = useState<File | null>(null);
+
+  const isAdminSurface = surface === "admin";
+  const backHref = isAdminSurface ? "/admin/gigs" : "/client/dashboard";
+  const backLabel = isAdminSurface ? "Back to All Opportunities" : "Back to Dashboard";
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { id, value } = e.target;
@@ -91,7 +102,7 @@ export function PostGigClient({
     try {
       if (mode === "edit") {
         if (!gigId) throw new Error("Missing opportunity identifier");
-        const result = await updateGigAction({
+        const payload = {
           gigId,
           title: formData.title,
           description: formData.description,
@@ -101,11 +112,14 @@ export function PostGigClient({
           duration: formData.duration,
           date: formData.date,
           application_deadline: formData.application_deadline || null,
-        });
+        };
+        const result = isAdminSurface ? await updateGigAsAdminAction(payload) : await updateGigAction(payload);
         if (!result.ok) throw new Error(result.error);
         toast({
           title: "Opportunity updated",
-          description: "Your changes have been saved.",
+          description: isAdminSurface
+            ? "Changes saved as administrator."
+            : "Your changes have been saved.",
         });
       } else {
         const result = await createGigAction({
@@ -128,7 +142,12 @@ export function PostGigClient({
         });
       }
 
-      router.push("/client/dashboard");
+      if (mode === "edit" && isAdminSurface && gigId) {
+        /** Navigate to admin detail so you can verify applicant context after save */
+        router.push(`/admin/gigs/${gigId}`);
+      } else {
+        router.push("/client/dashboard");
+      }
     } catch (err) {
       logger.error(mode === "edit" ? "Error updating gig" : "Error creating gig", err);
       setError(
@@ -150,7 +169,11 @@ export function PostGigClient({
           <div className="max-w-md mx-auto text-center">
             <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
             <h2 className="text-xl font-semibold text-foreground mb-2">Authentication Required</h2>
-            <p className="text-muted-foreground mb-4">You must be logged in to post a gig.</p>
+            <p className="text-muted-foreground mb-4">
+              {isAdminSurface
+                ? "You must be logged in as an administrator to edit this opportunity."
+                : "You must be logged in to post a gig."}
+            </p>
             <Button asChild>
               <Link href="/login">Log In</Link>
             </Button>
@@ -165,11 +188,11 @@ export function PostGigClient({
       <div className="min-h-screen">
         <div className="container mx-auto px-4 py-12">
           <Link
-            href="/client/dashboard"
+            href={backHref}
             className="inline-flex items-center text-muted-foreground hover:text-foreground mb-8 transition-colors"
           >
             <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Dashboard
+            {backLabel}
           </Link>
 
           <div className="max-w-3xl mx-auto rounded-3xl border border-border bg-card/80 shadow-2xl shadow-black/40 backdrop-blur overflow-hidden">
@@ -183,7 +206,7 @@ export function PostGigClient({
                 </AlertDescription>
               </Alert>
               <Button asChild>
-                <Link href="/client/dashboard">Back to Dashboard</Link>
+                <Link href={backHref}>{backLabel}</Link>
               </Button>
             </div>
           </div>
@@ -198,25 +221,41 @@ export function PostGigClient({
     <div className="min-h-screen" data-testid={isEdit ? "edit-gig-page" : undefined}>
       <div className="container mx-auto px-4 py-12">
         <Link
-          href="/client/dashboard"
+          href={backHref}
           className="inline-flex items-center text-muted-foreground hover:text-foreground mb-8 transition-colors"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to Dashboard
+          {backLabel}
         </Link>
 
         <div className="max-w-3xl mx-auto rounded-3xl border border-border bg-card/80 shadow-2xl shadow-black/40 backdrop-blur overflow-hidden">
           <div className="p-10 space-y-8">
             <div className="space-y-3">
               <h1 className="text-3xl font-bold text-foreground">
-                {isEdit ? "Edit opportunity" : "Post a New Opportunity"}
+                {isEdit
+                  ? isAdminSurface
+                    ? "Edit opportunity (admin)"
+                    : "Edit opportunity"
+                  : "Post a New Opportunity"}
               </h1>
               <p className="text-muted-foreground">
                 {isEdit
-                  ? "Update the details below. Changes apply immediately for talent viewing this opportunity."
+                  ? isAdminSurface
+                    ? "You are editing as a platform administrator. Changes apply immediately on the public listing."
+                    : "Update the details below. Changes apply immediately for talent viewing this opportunity."
                   : "Fill out the form below to create a new casting call or opportunity. Be as detailed as possible to attract the right talent."}
               </p>
             </div>
+
+            {isEdit && isAdminSurface && hasCompletedBookings && (
+              <Alert className="border-amber-500/50 bg-amber-500/10">
+                <AlertCircle className="h-4 w-4 text-amber-600" />
+                <AlertDescription className="text-amber-950 dark:text-amber-100">
+                  This opportunity has at least one completed booking. Editing may affect how historical records align with
+                  what talent and clients saw—use extra care.
+                </AlertDescription>
+              </Alert>
+            )}
 
             {isEdit && hasApplications && (
               <Alert className="border-amber-500/50 bg-amber-500/10">
@@ -370,7 +409,7 @@ export function PostGigClient({
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => router.push("/client/dashboard")}
+                  onClick={() => router.push(backHref)}
                   disabled={isSubmitting}
                 >
                   Cancel


### PR DESCRIPTION
## What broke

- **Admins could not edit opportunities** from **All Opportunities** (`/admin/gigs`): the ⋮ menu only offered **View**, and there was no admin-scoped server mutation or edit route. Career Builder edit existed only for **owners** on `/client/gigs/[id]/edit`.

## Why it broke

- Product work added **client-terminal** edit (`updateGigAction` + owner checks) but **never added** an **admin-terminal** equivalent. Admin list/detail UI had no wired **Edit** path and no **`updateGigAsAdminAction`**.

## What we changed

- **`app/admin/gigs/edit-actions.ts`:** **`updateGigAsAdminAction`** — verifies **`profiles.role === 'admin'`**, updates the same text fields as Career Builder edit (no cover-image change in this pass), **`revalidatePath`** for admin/client/public gig routes.
- **`app/admin/gigs/[id]/edit/page.tsx`:** RSC auth matches admin gig detail; loads gig; informational warning if **completed bookings** exist (save still allowed for admins).
- **`PostGigClient`:** **`surface: "client" | "admin"`**, **`hasCompletedBookings`** (admin warning); admin uses **`updateGigAsAdminAction`**, back/success nav to **`/admin/gigs`** and **`/admin/gigs/[id]`**.
- **`admin-gigs-client.tsx`:** ⋮ **Edit Opportunity**; mobile card **Edit** button.
- **`admin-gig-detail-client.tsx`:** **Edit** CTA next to view public page.
- **`MVP_STATUS_NOTION.md`:** Admin edit bullets under April 9, 2026 Career Builder edit section.

**Branch scope:** `main...develop` is **this single commit** (`c60bb06`) at the time of this PR (verify with `git log origin/main..develop --oneline`).

## How we proved it

Commands run before **commit** and **push** (all **exit 0**):

- `npm run schema:verify:comprehensive`
- `npm run types:check`
- `npm run build`
- `npm run lint`

**Pre-commit** on commit `c60bb06`: **passed** (includes build + lint).

**Manual / browser:** Not run in this session.

## Docs updated: yes

- `MVP_STATUS_NOTION.md`

## Risk + rollback

**Risk level:** **Low** (additive route + server action; relies on existing RLS **Admins can manage all gigs**; no migration).

**Rollback plan:** Revert **`c60bb06`** on `main`/`develop`, or delete the new route/action and revert UI links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds a new admin-only edit flow and server-side mutation for `gigs`, touching authorization checks and expanding who can update opportunity data. Risk centers on ensuring the `profiles.role === "admin"` gate and Supabase RLS correctly prevent non-admin updates and unintended field changes.
> 
> **Overview**
> Enables admins to edit any opportunity from the admin portal by adding a new `/admin/gigs/[id]/edit` page that loads gig fields server-side (plus application/completed-booking context) and reuses `PostGigClient` in an **admin** edit surface.
> 
> Introduces `updateGigAsAdminAction` to persist admin edits (explicit column updates + permission check via `profiles.role`) and triggers cache revalidation for admin, client, and public gig pages. Admin list/detail UIs now include **Edit** entry points, and the shared edit form adjusts navigation, copy, and warnings for the admin surface (completed bookings warn but do not block saves).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c60bb06411194c0dab388868ec99ea56130f2bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->