### PR TITLE
fix(ui): application flows atmosphere and admin gig reference links

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,18 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Application flows — lifted ambient + glass (April 10, 2026)**
+
+**UI / VIZB** — April 10, 2026
+- ✅ **`ambientTone="lifted"`** on **`TotlAtmosphereShell`** / **`PageShell`**: higher-key background and richer sky/violet wash via **`.totl-atmosphere-shell--lifted`** in `app/globals.css` for long forms (not a full light theme).
+- ✅ **Talent apply:** **`/gigs/[id]/apply`** uses **`PageShell`** + **`routeRole="talent"`**, frosted **`Card`**s (removed flat black/gray-900), **`getCategoryBadgeVariant`**, **`apply-to-gig-form`** uses token text + default **`Textarea`/`totl-input-shell`**; loading skeleton matches the shell.
+- ✅ **Career Builder apply:** **`/client/apply`** uses **`PageShell`** + lifted tone; form column gets a soft violet/sky wash; inputs use **`oklch`** + violet focus; submit CTA uses glow + gradient; fixed pending copy (“You’ll”).
+- ✅ **`GigReferenceLinksSection`:** single frosted treatment; links use **`--oklch-accent`** (removed **`variant="dark"`**).
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — run as part of ship.
+
+**Next (P1):** Reuse **`ambientTone="lifted"`** on other dense flows (e.g. onboarding, applications lists) for consistency.
+
 ## 🚀 **Latest: CI — admin users mobile Playwright selector (April 10, 2026)**
 
 **QA / PLAYWRIGHT** — April 10, 2026

--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -19,7 +19,7 @@
 
 **GIGS / CLIENT / TALENT** — April 10, 2026
 - ✅ **`gigs.reference_links`:** JSONB array on opportunities (max 15); kinds: company, reel, social, portfolio, press, other; Zod + `validate_gig_reference_links` CHECK; migration `20260410183000_add_gigs_reference_links.sql` applied to dev project + types regenerated.
-- ✅ **Career Builder / admin:** `PostGigClient` add/remove links on create and edit; server actions persist via explicit columns (`createGigAction`, `updateGigAction`, `updateGigAsAdminAction`).
+- ✅ **Career Builder / admin:** `PostGigClient` and **`/admin/gigs/create` (`CreateGigForm`)** add/remove links on create and edit; server actions persist via explicit columns (`createGigAction`, `updateGigAction`, `updateGigAsAdminAction`, `createGig` with `referenceLinkRows`).
 - ✅ **Talent:** `GigReferenceLinksSection` on public **`/gigs/[id]`** and **`/gigs/[id]/apply`** (not on browse cards in this slice).
 - ✅ **Tests:** `lib/gig-reference-links.test.ts` (Vitest).
 

--- a/app/admin/gigs/create/actions.ts
+++ b/app/admin/gigs/create/actions.ts
@@ -2,11 +2,13 @@
 
 import { revalidatePath } from "next/cache";
 import { uploadGigImage, deleteGigImage } from "@/lib/actions/gig-actions";
+import type { GigReferenceLinkFormRow } from "@/lib/gig-reference-links";
+import { parseReferenceLinksForDatabase } from "@/lib/gig-reference-links";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 import { logger } from "@/lib/utils/logger";
 import type { Database } from "@/types/supabase";
 
-export async function createGig(formData: FormData) {
+export async function createGig(formData: FormData, referenceLinkRows: GigReferenceLinkFormRow[] = []) {
   const supabase = await createSupabaseServer();
 
   // Get authenticated user
@@ -58,6 +60,11 @@ export async function createGig(formData: FormData) {
   const maxComp = parseInt(compensationMax) || 0;
   const compensation = maxComp > minComp ? `$${minComp} - $${maxComp}` : `$${minComp}`;
 
+  const linksResult = parseReferenceLinksForDatabase(referenceLinkRows);
+  if (!linksResult.ok) {
+    return { error: linksResult.error };
+  }
+
   // Upload image if provided (before DB insert to enable cleanup on failure)
   let imageUrl: string | null = null;
   if (imageFile && imageFile.size > 0) {
@@ -86,8 +93,9 @@ export async function createGig(formData: FormData) {
       date: startDate || new Date().toISOString().split("T")[0],
       image_url: imageUrl,
       status: "active" as const,
+      reference_links: linksResult.data,
     })
-    .select()
+    .select("id")
     .single();
 
   // If DB insert fails but image was uploaded, clean up orphaned image

--- a/app/admin/gigs/create/create-gig-form.tsx
+++ b/app/admin/gigs/create/create-gig-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Plus, Minus, Calendar, DollarSign, MapPin } from "lucide-react";
+import { ArrowLeft, Plus, Minus, Calendar, DollarSign, MapPin, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useActionState } from "react";
@@ -20,6 +20,11 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { VISIBLE_GIG_CATEGORIES, getCategoryLabel } from "@/lib/constants/gig-categories";
+import {
+  GIG_REFERENCE_LINK_KINDS,
+  type GigReferenceLinkFormRow,
+  referenceLinkKindLabel,
+} from "@/lib/gig-reference-links";
 
 function SubmitButton() {
   const { pending } = useFormStatus();
@@ -31,10 +36,13 @@ function SubmitButton() {
   );
 }
 
+const MAX_REFERENCE_LINKS = 15;
+
 export function CreateGigForm() {
   const [requirements, setRequirements] = useState<string[]>([""]);
   const [category, setCategory] = useState<string>("modeling");
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const [referenceLinks, setReferenceLinks] = useState<GigReferenceLinkFormRow[]>([]);
   const router = useRouter();
   const [state, formAction] = useActionState(
     async (prevState: { error?: string; success?: boolean } | null, formData: FormData) => {
@@ -42,7 +50,7 @@ export function CreateGigForm() {
       if (imageFile) {
         formData.append("gig_image", imageFile);
       }
-      const result = await createGig(formData);
+      const result = await createGig(formData, referenceLinks);
       if (result?.success) {
         // Redirect to dashboard on success
         router.push("/admin/dashboard");
@@ -67,6 +75,26 @@ export function CreateGigForm() {
     const newRequirements = [...requirements];
     newRequirements[index] = value;
     setRequirements(newRequirements);
+  };
+
+  const updateReferenceLink = (index: number, patch: Partial<GigReferenceLinkFormRow>) => {
+    setReferenceLinks((prev) => {
+      const next = [...prev];
+      const row = next[index] ?? { url: "", label: "", kind: "" };
+      next[index] = { ...row, ...patch };
+      return next;
+    });
+  };
+
+  const addReferenceLinkRow = () => {
+    setReferenceLinks((prev) => {
+      if (prev.length >= MAX_REFERENCE_LINKS) return prev;
+      return [...prev, { url: "", label: "", kind: "" }];
+    });
+  };
+
+  const removeReferenceLinkRow = (index: number) => {
+    setReferenceLinks((prev) => prev.filter((_, i) => i !== index));
   };
 
   return (
@@ -216,6 +244,106 @@ export function CreateGigForm() {
                     />
                   </div>
                 </div>
+              </div>
+
+              <div className="space-y-4 rounded-lg border border-gray-700/80 bg-gray-800/40 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <Label className="text-base text-white">Reference links (optional)</Label>
+                    <p className="text-sm text-gray-400">
+                      Company site, reels, social, portfolio—help talent see the vibe. Up to {MAX_REFERENCE_LINKS}{" "}
+                      links, http(s) only.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={addReferenceLinkRow}
+                    disabled={referenceLinks.length >= MAX_REFERENCE_LINKS || state?.success === true}
+                    className="shrink-0 border-gray-600 text-gray-200 hover:bg-gray-800"
+                  >
+                    <Plus className="mr-1 h-4 w-4" />
+                    Add link
+                  </Button>
+                </div>
+                {referenceLinks.length === 0 ? (
+                  <p className="text-sm text-gray-500">No reference links yet.</p>
+                ) : (
+                  <ul className="space-y-4">
+                    {referenceLinks.map((row, idx) => (
+                      <li
+                        key={idx}
+                        className="grid grid-cols-1 gap-3 rounded-md border border-gray-700/60 bg-gray-900/50 p-3 md:grid-cols-12 md:items-end"
+                      >
+                        <div className="md:col-span-5 space-y-2">
+                          <Label htmlFor={`ref-url-${idx}`} className="text-white">
+                            URL
+                          </Label>
+                          <Input
+                            id={`ref-url-${idx}`}
+                            placeholder="https://…"
+                            value={row.url}
+                            onChange={(e) => updateReferenceLink(idx, { url: e.target.value })}
+                            className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                          />
+                        </div>
+                        <div className="md:col-span-4 space-y-2">
+                          <Label htmlFor={`ref-label-${idx}`} className="text-white">
+                            Label
+                          </Label>
+                          <Input
+                            id={`ref-label-${idx}`}
+                            placeholder="e.g. Brand reel"
+                            value={row.label}
+                            onChange={(e) => updateReferenceLink(idx, { label: e.target.value })}
+                            className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                          />
+                        </div>
+                        <div className="md:col-span-2 space-y-2">
+                          <Label htmlFor={`ref-kind-${idx}`} className="text-white">
+                            Type
+                          </Label>
+                          <Select
+                            value={row.kind || undefined}
+                            onValueChange={(value) =>
+                              updateReferenceLink(idx, {
+                                kind: value as GigReferenceLinkFormRow["kind"],
+                              })
+                            }
+                          >
+                            <SelectTrigger
+                              id={`ref-kind-${idx}`}
+                              className="bg-gray-800 border-gray-700 text-white data-[placeholder]:text-gray-500"
+                            >
+                              <SelectValue placeholder="Select" />
+                            </SelectTrigger>
+                            <SelectContent className="bg-gray-800 border-gray-700 text-white">
+                              {GIG_REFERENCE_LINK_KINDS.map((k) => (
+                                <SelectItem key={k} value={k} className="focus:bg-gray-700 focus:text-white">
+                                  {referenceLinkKindLabel(k)}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        <div className="flex md:col-span-1 md:justify-end">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => removeReferenceLinkRow(idx)}
+                            disabled={state?.success === true}
+                            className="text-rose-400 hover:bg-gray-800 hover:text-rose-300"
+                            aria-label="Remove link"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
 
               <div className="space-y-4">

--- a/app/client/apply/page.tsx
+++ b/app/client/apply/page.tsx
@@ -7,6 +7,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/components/auth/auth-provider";
+import { PageShell } from "@/components/layout/page-shell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -260,43 +261,46 @@ export default function ClientApplicationPage() {
     !isCareerBuilder &&
     (hasStartedEditing || !applicationStatus?.status) &&
     !isCheckingStatus;
-  const labelClass = "text-sm font-semibold text-white/80";
+  const labelClass = "text-sm font-semibold text-[var(--oklch-text-secondary)]";
   const inputClass =
-    "border-border/50 bg-card/45 text-white placeholder:text-white/45 focus-visible:border-amber-500";
+    "border-border/45 bg-card/50 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)] focus-visible:border-[var(--totl-violet-light)]";
 
   if (authLoading && user) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--oklch-bg)] px-4 pt-20 text-white sm:pt-24">
-        <p className="text-white/70 text-center">Loading your account…</p>
-      </div>
+      <PageShell ambientTone="lifted">
+        <div className="flex min-h-[50vh] items-center justify-center px-4">
+          <p className="text-[var(--oklch-text-muted)] text-center">Loading your account…</p>
+        </div>
+      </PageShell>
     );
   }
 
   if (user && isCareerBuilder) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[var(--oklch-bg)] px-4 pt-20 text-white sm:pt-24">
-        <p className="text-white/70 text-center">Redirecting to your Career Builder dashboard…</p>
-      </div>
+      <PageShell ambientTone="lifted">
+        <div className="flex min-h-[50vh] items-center justify-center px-4">
+          <p className="text-[var(--oklch-text-muted)] text-center">Redirecting to your Career Builder dashboard…</p>
+        </div>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-[var(--oklch-bg)] pt-20 text-white sm:pt-24">
-      <div className="container mx-auto px-4 py-4 sm:py-12">
-        <Link
-          href={returnUrl ? decodeURIComponent(returnUrl) : "/"}
-          className="inline-flex items-center text-white/70 hover:text-white mb-4 sm:mb-8"
-        >
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back
-        </Link>
+    <PageShell ambientTone="lifted" containerClassName="py-4 sm:py-12">
+      <Link
+        href={returnUrl ? decodeURIComponent(returnUrl) : "/"}
+        className="inline-flex items-center text-[var(--oklch-text-muted)] hover:text-[var(--oklch-text-primary)] mb-4 sm:mb-8 transition-colors"
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" />
+        Back
+      </Link>
 
-        <div className="mx-auto max-w-4xl overflow-hidden rounded-3xl panel-frosted card-backlit shadow-xl">
+      <div className="mx-auto max-w-4xl overflow-hidden rounded-3xl panel-frosted card-backlit shadow-xl">
           {statusMessage && (
             <div className="border-b border-border/40 bg-card/25 p-4">
-              <Alert className="border-border/40 bg-card/25 text-white">
-                <AlertTitle className="text-white">Career Builder Application</AlertTitle>
-                <AlertDescription className="text-white/80">{statusMessage}</AlertDescription>
+              <Alert className="border-border/40 bg-card/20">
+                <AlertTitle className="text-[var(--oklch-text-primary)]">Career Builder Application</AlertTitle>
+                <AlertDescription className="text-[var(--oklch-text-muted)]">{statusMessage}</AlertDescription>
               </Alert>
             </div>
           )}
@@ -309,8 +313,8 @@ export default function ClientApplicationPage() {
                   fill
                   className="object-cover"
                 />
-                <div className="absolute inset-0 bg-gradient-to-r from-slate-950/90 to-transparent"></div>
-                <div className="absolute inset-0 bg-gradient-to-r from-black/60 to-transparent"></div>
+                <div className="absolute inset-0 bg-gradient-to-r from-slate-950/70 via-slate-900/35 to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-r from-violet-950/25 to-transparent" />
                 <div className="absolute bottom-0 left-0 p-8 text-white">
                   <h2 className="text-2xl font-bold mb-2">Apply to Become a Career Builder</h2>
                   <p className="text-white/80">
@@ -320,10 +324,10 @@ export default function ClientApplicationPage() {
               </div>
             </div>
 
-            <div className="bg-card/10 p-8 md:col-span-3">
+            <div className="bg-gradient-to-br from-violet-500/[0.08] via-card/16 to-sky-500/[0.05] p-8 md:col-span-3">
               <div className="mb-8">
                 <h1 className="text-2xl font-bold mb-2">Career Builder Application</h1>
-                <p className="text-white/70">
+                <p className="text-[var(--oklch-text-muted)]">
                   Complete the form below to apply as a Career Builder with TOTL Agency. Our team will
                   review your application and contact you within 2-3 business days.
                 </p>
@@ -331,10 +335,10 @@ export default function ClientApplicationPage() {
 
               {showStatusPanel ? (
                 <div className="panel-frosted card-backlit rounded-2xl p-6 text-left">
-                  <p className="text-white font-semibold mb-2">Application Under Review</p>
-                  <p className="text-white/70 text-sm">
-                    {applicationStatus.status === 'pending'
-                      ? "We received your application and our admin team is reviewing it. You&apos;ll be notified when we have an update."
+                  <p className="text-[var(--oklch-text-primary)] font-semibold mb-2">Application Under Review</p>
+                  <p className="text-[var(--oklch-text-muted)] text-sm">
+                    {applicationStatus.status === "pending"
+                      ? "We received your application and our admin team is reviewing it. You'll be notified when we have an update."
                       : applicationStatus.status === 'rejected'
                         ? 'Your application was rejected. Please reach out to hello@thetotlagency.com to reapply.'
                         : 'We found an existing application. Check your email for the latest status.'}
@@ -342,13 +346,13 @@ export default function ClientApplicationPage() {
                 </div>
               ) : isCheckingStatus ? (
                 <div className="panel-frosted card-backlit rounded-2xl p-6 text-left">
-                  <p className="text-white font-semibold mb-2">Checking application status</p>
-                  <p className="text-white/70 text-sm">
+                  <p className="text-[var(--oklch-text-primary)] font-semibold mb-2">Checking application status</p>
+                  <p className="text-[var(--oklch-text-muted)] text-sm">
                     Finalizing your sign-in and checking whether you already have a Career Builder application on file.
                   </p>
                 </div>
               ) : shouldShowForm ? (
-                <form className="space-y-6 text-white" onSubmit={handleSubmit}>
+                <form className="space-y-6 text-[var(--oklch-text-primary)]" onSubmit={handleSubmit}>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <div className="space-y-2">
                       <Label className={labelClass} htmlFor="firstName">
@@ -426,7 +430,7 @@ export default function ClientApplicationPage() {
                       Industry
                     </Label>
                     <Select value={formData.industry} onValueChange={handleSelectChange}>
-                      <SelectTrigger id="industry" className="border-border/50 bg-card/45 text-white">
+                      <SelectTrigger id="industry" className={inputClass}>
                         <SelectValue placeholder="Select your industry" />
                       </SelectTrigger>
                       <SelectContent>
@@ -486,7 +490,7 @@ export default function ClientApplicationPage() {
                   <div className="pt-4">
                     <Button
                       type="submit"
-                      className="w-full bg-amber-500 text-black hover:bg-amber-400"
+                      className="w-full button-glow border-0 bg-gradient-to-r from-amber-400 to-amber-500 text-black hover:from-amber-300 hover:to-amber-400"
                       disabled={
                         isSubmitting ||
                         applicationStatus?.status === "pending"
@@ -494,13 +498,13 @@ export default function ClientApplicationPage() {
                     >
                       {isSubmitting ? "Submitting..." : "Submit Application"}
                     </Button>
-                    <p className="text-sm text-white/60 mt-4 text-left">
+                    <p className="text-sm text-[var(--oklch-text-muted)] mt-4 text-left">
                       By submitting this form, you agree to our{" "}
-                      <Link href="/terms" className="underline text-white/70">
+                      <Link href="/terms" className="underline text-[var(--oklch-accent)] hover:brightness-110">
                         Terms of Service
                       </Link>{" "}
                       and{" "}
-                      <Link href="/privacy" className="underline text-white/70">
+                      <Link href="/privacy" className="underline text-[var(--oklch-accent)] hover:brightness-110">
                         Privacy Policy
                       </Link>
                       .
@@ -511,7 +515,6 @@ export default function ClientApplicationPage() {
             </div>
           </div>
         </div>
-      </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/gigs/[id]/apply/apply-to-gig-form.tsx
+++ b/app/gigs/[id]/apply/apply-to-gig-form.tsx
@@ -164,10 +164,10 @@ export function ApplyToGigForm({ gig }: ApplyToGigFormProps) {
   return (
     <form onSubmit={handleApply} className="space-y-6">
       <div className="space-y-2">
-        <label htmlFor="coverLetter" className="text-sm font-medium text-white">
+        <label htmlFor="coverLetter" className="text-sm font-medium text-[var(--oklch-text-primary)]">
           Cover Letter (Optional)
         </label>
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-[var(--oklch-text-muted)]">
           Your profile and portfolio are included automatically.
         </p>
         <Textarea
@@ -175,10 +175,10 @@ export function ApplyToGigForm({ gig }: ApplyToGigFormProps) {
           value={coverLetter}
           onChange={(e) => setCoverLetter(e.target.value)}
           placeholder="Tell the client why you're perfect for this opportunity. Include any relevant experience, availability, or special skills..."
-          className="min-h-[120px] bg-gray-800 border-gray-600 text-white placeholder-gray-400"
+          className="min-h-[120px]"
           maxLength={1000}
         />
-        <p className="text-xs text-gray-400">{coverLetter.length}/1000 characters</p>
+        <p className="text-xs text-[var(--oklch-text-muted)]">{coverLetter.length}/1000 characters</p>
       </div>
 
       <div className="flex gap-3">
@@ -195,20 +195,14 @@ export function ApplyToGigForm({ gig }: ApplyToGigFormProps) {
             </>
           )}
         </Button>
-        <Button
-          type="button"
-          variant="outline"
-          disabled={submitting}
-          onClick={() => router.push(`/gigs/${gig.id}`)}
-          className="border-gray-600 text-gray-300 hover:bg-gray-800"
-        >
+        <Button type="button" variant="outline" disabled={submitting} onClick={() => router.push(`/gigs/${gig.id}`)}>
           Cancel
         </Button>
       </div>
 
       {error && (
-        <Alert variant="destructive" className="bg-red-500/10 border-red-500/20">
-          <AlertDescription className="text-red-300">{error}</AlertDescription>
+        <Alert variant="destructive" className="bg-red-500/10 border-red-500/30">
+          <AlertDescription className="text-[var(--oklch-text-secondary)]">{error}</AlertDescription>
         </Alert>
       )}
     </form>

--- a/app/gigs/[id]/apply/loading.tsx
+++ b/app/gigs/[id]/apply/loading.tsx
@@ -1,31 +1,31 @@
+import { PageShell } from "@/components/layout/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export default function ApplyToGigLoading() {
   return (
-    <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient pt-40">
-      <div className="container mx-auto px-4 py-8">
-        <div className="max-w-2xl mx-auto space-y-6">
-          {/* Back link skeleton */}
-          <Skeleton className="h-5 w-28 bg-zinc-800/50" />
+    <PageShell ambientTone="lifted" routeRole="talent" containerClassName="py-8 sm:py-12">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <Skeleton className="h-10 w-56 rounded-lg bg-muted/40" />
 
-          {/* Gig summary skeleton */}
-          <div className="rounded-xl border border-zinc-800/50 bg-zinc-900/30 p-4">
-            <Skeleton className="h-6 w-48 mb-2 bg-zinc-800/50" />
-            <Skeleton className="h-4 w-full bg-zinc-800/50" />
+        <div className="panel-frosted card-backlit rounded-[1.5rem] p-6 space-y-4">
+          <Skeleton className="h-8 w-3/4 max-w-md rounded-lg bg-muted/40" />
+          <Skeleton className="h-4 w-full rounded-lg bg-muted/30" />
+          <Skeleton className="h-4 w-full rounded-lg bg-muted/30" />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
+            <Skeleton className="h-14 rounded-xl bg-muted/35" />
+            <Skeleton className="h-14 rounded-xl bg-muted/35" />
           </div>
+        </div>
 
-          {/* Form skeleton */}
-          <div className="space-y-4 rounded-xl border border-zinc-800/50 bg-zinc-900/30 p-6">
-            <Skeleton className="h-8 w-40 bg-zinc-800/50" />
-            <Skeleton className="h-24 w-full bg-zinc-800/50" />
-            <Skeleton className="h-24 w-full bg-zinc-800/50" />
-            <div className="flex justify-end gap-2 pt-4">
-              <Skeleton className="h-10 w-24 bg-zinc-800/50" />
-              <Skeleton className="h-10 w-32 bg-zinc-800/50" />
-            </div>
+        <div className="panel-frosted card-backlit rounded-[1.5rem] p-6 space-y-4">
+          <Skeleton className="h-7 w-48 rounded-lg bg-muted/40" />
+          <Skeleton className="h-28 w-full rounded-xl bg-muted/35" />
+          <div className="flex flex-col-reverse gap-3 pt-2 sm:flex-row sm:justify-end">
+            <Skeleton className="h-11 flex-1 rounded-xl bg-muted/35 sm:max-w-[140px]" />
+            <Skeleton className="h-11 flex-1 rounded-xl bg-muted/35" />
           </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/gigs/[id]/apply/page.tsx
+++ b/app/gigs/[id]/apply/page.tsx
@@ -3,12 +3,13 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { ApplyToGigForm } from "./apply-to-gig-form";
 import { GigReferenceLinksSection } from "@/components/gigs/gig-reference-links-section";
+import { PageShell } from "@/components/layout/page-shell";
 import { SubscriptionPrompt } from "@/components/subscription-prompt";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent, CardDescription } from "@/components/ui/card";
-import { getCategoryLabel } from "@/lib/constants/gig-categories";
+import { getCategoryBadgeVariant, getCategoryLabel } from "@/lib/constants/gig-categories";
 import { GIG_PUBLIC_SELECT } from "@/lib/db/selects";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 
@@ -68,106 +69,95 @@ export default async function ApplyToGigPage({ params }: ApplyToGigPageProps) {
 
   const alreadyApplied = !!existingApplication;
 
-  // Note: Category color logic can be enhanced with getCategoryBadgeVariant if needed
-  // For now, keeping a simple fallback since badge styling may vary
-  const getCategoryColor = () => {
-    // Default fallback - can be enhanced with getCategoryBadgeVariant
-    return "bg-gray-100 text-gray-800";
-  };
-
   return (
-    <div className="min-h-screen bg-black pt-24">
-      <div className="container mx-auto px-4 py-12">
-        <div className="max-w-2xl mx-auto">
-          {/* Back Button */}
-          <div className="mb-6">
-            <Button variant="ghost" asChild className="text-white hover:bg-gray-800">
-              <Link href={`/gigs/${gig.id}`} className="flex items-center gap-2">
-                <ArrowLeft className="h-4 w-4" />
-                Back to Opportunity Details
-              </Link>
-            </Button>
-          </div>
+    <PageShell ambientTone="lifted" routeRole="talent" containerClassName="py-8 sm:py-12">
+      <div className="max-w-2xl mx-auto">
+        <div className="mb-6">
+          <Button variant="ghost" asChild>
+            <Link href={`/gigs/${gig.id}`} className="flex items-center gap-2 text-[var(--oklch-text-secondary)]">
+              <ArrowLeft className="h-4 w-4" />
+              Back to Opportunity Details
+            </Link>
+          </Button>
+        </div>
 
-          {/* Main Content */}
-          <div className="space-y-6">
-            {/* Gig Summary Card */}
-            <Card className="bg-gray-900 border-gray-700">
-              <CardHeader>
-                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-                  <div>
-                    <CardTitle className="text-2xl font-bold text-white">{gig.title}</CardTitle>
-                    <CardDescription className="text-lg mt-2 text-gray-300">{gig.description}</CardDescription>
-                  </div>
-                  <Badge className={getCategoryColor()}>
-                    {getCategoryLabel(gig.category || "")}
-                  </Badge>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+                <div>
+                  <CardTitle className="text-2xl font-bold">{gig.title}</CardTitle>
+                  <CardDescription className="text-base mt-2">{gig.description}</CardDescription>
                 </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                  <div>
-                    <span className="font-medium text-gray-300">Location:</span>
-                    <p className="text-gray-400">{gig.location}</p>
-                  </div>
-                  <div>
-                    <span className="font-medium text-gray-300">Compensation:</span>
-                    <p className="text-gray-400">${gig.compensation}</p>
-                  </div>
-                  {gig.date && (
-                    <div>
-                      <span className="font-medium text-gray-300">Date:</span>
-                      <p className="text-gray-400">{new Date(gig.date).toLocaleDateString()}</p>
-                    </div>
-                  )}
+                <Badge variant={getCategoryBadgeVariant(gig.category || "")}>
+                  {getCategoryLabel(gig.category || "")}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                <div>
+                  <span className="font-medium text-[var(--oklch-text-secondary)]">Location:</span>
+                  <p className="text-[var(--oklch-text-tertiary)]">{gig.location}</p>
                 </div>
-              </CardContent>
-            </Card>
-
-            <GigReferenceLinksSection referenceLinks={gig.reference_links} variant="dark" />
-
-            {/* Application Form */}
-            <Card className="bg-gray-900 border-gray-700">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-white">
-                  <Send className="h-5 w-5" />
-                  Submit Application
-                </CardTitle>
-                <CardDescription className="text-gray-300">
-                  Complete your application for this gig. Your profile information will be
-                  automatically included.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {alreadyApplied ? (
-                  <Alert className="bg-green-500/10 border-green-500/20">
-                    <CheckCircle className="h-4 w-4 text-green-400" />
-                    <AlertDescription className="text-green-300">
-                      You have already applied for this gig. Check your dashboard for updates on
-                      your application status.
-                    </AlertDescription>
-                  </Alert>
-                ) : hasActiveSubscription ? (
-                  <ApplyToGigForm gig={gig} />
-                ) : (
-                  <div className="space-y-4" data-testid="subscription-apply-form-gate">
-                    <Alert className="bg-amber-500/10 border-amber-500/20">
-                      <AlertDescription className="text-amber-100">
-                        Subscribe to unlock applications. You can still browse gigs, but applying
-                        requires an active plan.
-                      </AlertDescription>
-                    </Alert>
-                    <SubscriptionPrompt profile={promptProfile} variant="card" context="gig-apply" />
-                    <Button asChild className="w-full button-glow border-0">
-                      <Link href="/talent/subscribe">View Plans</Link>
-                    </Button>
+                <div>
+                  <span className="font-medium text-[var(--oklch-text-secondary)]">Compensation:</span>
+                  <p className="text-[var(--oklch-text-tertiary)]">${gig.compensation}</p>
+                </div>
+                {gig.date && (
+                  <div>
+                    <span className="font-medium text-[var(--oklch-text-secondary)]">Date:</span>
+                    <p className="text-[var(--oklch-text-tertiary)]">
+                      {new Date(gig.date).toLocaleDateString()}
+                    </p>
                   </div>
                 )}
-              </CardContent>
-            </Card>
-          </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <GigReferenceLinksSection referenceLinks={gig.reference_links} />
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Send className="h-5 w-5 text-[var(--oklch-accent)]" aria-hidden />
+                Submit Application
+              </CardTitle>
+              <CardDescription>
+                Complete your application for this gig. Your profile information will be automatically
+                included.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {alreadyApplied ? (
+                <Alert className="border-emerald-500/35 bg-emerald-500/10">
+                  <CheckCircle className="h-4 w-4 text-emerald-400" />
+                  <AlertDescription className="text-[var(--oklch-text-secondary)]">
+                    You have already applied for this gig. Check your dashboard for updates on your
+                    application status.
+                  </AlertDescription>
+                </Alert>
+              ) : hasActiveSubscription ? (
+                <ApplyToGigForm gig={gig} />
+              ) : (
+                <div className="space-y-4" data-testid="subscription-apply-form-gate">
+                  <Alert className="border-amber-400/35 bg-amber-500/10">
+                    <AlertDescription className="text-[var(--oklch-text-secondary)]">
+                      Subscribe to unlock applications. You can still browse gigs, but applying requires an
+                      active plan.
+                    </AlertDescription>
+                  </Alert>
+                  <SubscriptionPrompt profile={promptProfile} variant="card" context="gig-apply" />
+                  <Button asChild className="w-full button-glow border-0">
+                    <Link href="/talent/subscribe">View Plans</Link>
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -782,6 +782,33 @@
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
+/**
+ * Lifted ambient stack: slightly higher-key base + richer sky/violet wash for long forms
+ * (applications, multi-step flows) without flipping the whole product to a light theme.
+ */
+.totl-atmosphere-shell--lifted {
+  background:
+    radial-gradient(circle at 50% -8%, rgba(255, 255, 255, 0.065), transparent 36%),
+    linear-gradient(180deg, #10101a 0%, #17172c 42%, #0c0c14 100%);
+}
+
+.totl-atmosphere-shell--lifted .totl-atmosphere-base {
+  opacity: 1;
+  background:
+    radial-gradient(circle at 12% 14%, rgba(255, 255, 255, 0.075), transparent 0 22%),
+    radial-gradient(circle at 85% 16%, rgba(186, 167, 255, 0.11), transparent 0 26%),
+    radial-gradient(circle at 45% 76%, rgba(125, 211, 252, 0.075), transparent 0 24%);
+}
+
+.totl-atmosphere-shell--lifted .totl-atmosphere-glow {
+  filter: blur(12px);
+  background:
+    radial-gradient(ellipse 72% 54% at 50% -14%, rgba(255, 255, 255, 0.09), transparent 62%),
+    radial-gradient(ellipse 54% 40% at 10% 10%, rgba(148, 197, 255, 0.08), transparent 58%),
+    radial-gradient(ellipse 48% 36% at 90% 14%, rgba(186, 167, 255, 0.1), transparent 55%),
+    radial-gradient(ellipse 66% 46% at 50% 108%, rgba(139, 92, 246, 0.14), transparent 60%);
+}
+
 .totl-section-divider {
   --totl-divider-line-current: var(--totl-divider-line);
   --totl-divider-violet-current: var(--totl-divider-violet);

--- a/components/gigs/gig-reference-links-section.tsx
+++ b/components/gigs/gig-reference-links-section.tsx
@@ -12,22 +12,19 @@ import type { Json } from "@/types/database";
 
 type GigReferenceLinksSectionProps = {
   referenceLinks: Json | null | undefined;
-  /** Light cards (apply page) vs default */
-  variant?: "default" | "dark";
 };
 
-export function GigReferenceLinksSection({ referenceLinks, variant = "default" }: GigReferenceLinksSectionProps) {
+export function GigReferenceLinksSection({ referenceLinks }: GigReferenceLinksSectionProps) {
   const links = parseStoredReferenceLinksForDisplay(referenceLinks);
   if (links.length === 0) return null;
 
-  const isDark = variant === "dark";
-
   return (
-    <Card className={isDark ? "bg-gray-900 border-gray-700" : undefined}>
+    <Card>
       <CardHeader>
-        <CardTitle className={isDark ? "text-white" : undefined}>Reference & inspiration</CardTitle>
-        <CardDescription className={isDark ? "text-gray-300" : undefined}>
-          Links from the career builder to help you understand the creative direction (reels, campaigns, etc.).
+        <CardTitle>Reference & inspiration</CardTitle>
+        <CardDescription>
+          Links from the career builder to help you understand the creative direction (reels, campaigns,
+          etc.).
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -39,11 +36,7 @@ export function GigReferenceLinksSection({ referenceLinks, variant = "default" }
                   href={link.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={
-                    isDark
-                      ? "inline-flex items-center gap-2 text-sky-400 hover:text-sky-300 underline-offset-4 hover:underline"
-                      : "inline-flex items-center gap-2 text-primary underline-offset-4 hover:underline"
-                  }
+                  className="inline-flex items-center gap-2 text-[var(--oklch-accent)] underline-offset-4 hover:underline"
                 >
                   <span className="font-medium">{link.label}</span>
                   <Badge variant="secondary" className="font-normal">

--- a/components/layout/page-shell.tsx
+++ b/components/layout/page-shell.tsx
@@ -1,6 +1,10 @@
 import type React from "react";
 
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
+import {
+  TotlAtmosphereShell,
+  type TotlAmbientTone,
+  type TotlRouteRole,
+} from "@/components/ui/totl-atmosphere-shell";
 import { cn } from "@/lib/utils/utils";
 
 export interface PageShellProps {
@@ -17,6 +21,8 @@ export interface PageShellProps {
    * Default is false (containerized pages).
    */
   fullBleed?: boolean;
+  ambientTone?: TotlAmbientTone;
+  routeRole?: TotlRouteRole;
 }
 
 export function PageShell({
@@ -25,9 +31,13 @@ export function PageShell({
   className,
   containerClassName,
   fullBleed = false,
+  ambientTone = "default",
+  routeRole,
 }: PageShellProps) {
   return (
     <TotlAtmosphereShell
+      ambientTone={ambientTone}
+      routeRole={routeRole}
       className={cn("text-[var(--oklch-text-primary)]", className)}
       contentClassName={cn(topPadding && "pt-20 sm:pt-24")}
     >

--- a/components/ui/totl-atmosphere-shell.tsx
+++ b/components/ui/totl-atmosphere-shell.tsx
@@ -2,11 +2,18 @@ import type React from "react";
 
 import { cn } from "@/lib/utils/utils";
 
+export type TotlAmbientTone = "default" | "lifted";
+export type TotlRouteRole = "talent" | "client" | "admin";
+
 interface TotlAtmosphereShellProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   contentClassName?: string;
   withGrid?: boolean;
   withNoise?: boolean;
+  /** Slightly brighter ambient stack for long forms (applications, onboarding). */
+  ambientTone?: TotlAmbientTone;
+  /** Sets `data-role` for inherited spotlight / token tuning (use on routes outside role layouts). */
+  routeRole?: TotlRouteRole;
 }
 
 export function TotlAtmosphereShell({
@@ -15,10 +22,20 @@ export function TotlAtmosphereShell({
   contentClassName,
   withGrid = true,
   withNoise = true,
+  ambientTone = "default",
+  routeRole,
   ...props
 }: TotlAtmosphereShellProps) {
   return (
-    <div className={cn("totl-atmosphere-shell", className)} {...props}>
+    <div
+      className={cn(
+        "totl-atmosphere-shell",
+        ambientTone === "lifted" && "totl-atmosphere-shell--lifted",
+        className
+      )}
+      data-role={routeRole}
+      {...props}
+    >
       <div className="totl-atmosphere-layer totl-atmosphere-base" aria-hidden />
       <div className="totl-atmosphere-layer totl-atmosphere-glow" aria-hidden />
       {withGrid ? <div className="totl-atmosphere-layer totl-atmosphere-grid" aria-hidden /> : null}

--- a/docs/contracts/GIGS_CONTRACT.md
+++ b/docs/contracts/GIGS_CONTRACT.md
@@ -29,7 +29,7 @@ Admin/ops
 ## Canonical server actions/services
 
 - `app/admin/gigs/create/actions.ts`
-  - `createGig(formData)`
+  - `createGig(formData, referenceLinkRows?)` — second arg optional; persisted as `gigs.reference_links` when valid.
 
 - `app/gigs/[id]/apply/actions.ts`
   - `applyToGig({ gigId, message? })`


### PR DESCRIPTION
What broke

1) Admin **Create opportunity** at `/admin/gigs/create` did not collect or persist **`gigs.reference_links`**, so showcase/inspiration links were missing on that path.
2) **Talent apply** (`/gigs/[id]/apply`) and **Career Builder apply** (`/client/apply`) felt overly flat and dark (legacy black/gray) compared to the frosted **TOTL** shell.

Why it broke

1) Reference links were implemented for Career Builder post/edit flows first; the admin create surface used a separate form/action that was not wired to the same JSONB column and validation.
2) Gig apply predated **`PageShell` / `TotlAtmosphereShell`** improvements; client apply used a plain dark viewport without the **lifted** ambient stack.

What we changed

**Commits on `develop` not on `main`:** `dd027a7`, `bf14b50`.

- **`dd027a7` — admin create reference links:** `CreateGigForm` UI; `createGig(..., referenceLinkRows)` + `reference_links` on insert; `docs/contracts/GIGS_CONTRACT.md`; `MVP_STATUS_NOTION.md`.
- **`bf14b50` — application / VIZB:** `ambientTone="lifted"` + optional `routeRole` on `TotlAtmosphereShell` / `PageShell`; **`.totl-atmosphere-shell--lifted`** in `app/globals.css`; talent apply uses **`PageShell`**, frosted cards, badge variants, token copy; **`apply-to-gig-form`** uses default `Textarea` / `totl-input-shell`; apply **loading** matches shell; **`/client/apply`** uses **`PageShell`**, softer hero scrim, violet/sky form wash, CTA glow; **`GigReferenceLinksSection`** unified frosted treatment + accent links (removed `variant="dark"`); `MVP_STATUS_NOTION.md`.

How we proved it

Commands run locally (all succeeded, exit code 0):

- `npm run schema:verify:comprehensive`
- `npm run types:check`
- `npm run build`
- `npm run lint`

Repository **pre-commit** hook also runs guards, **build**, and **lint** before commits.

Manual / browser checks: **not run** in this session.

Docs updated: **yes**

- `MVP_STATUS_NOTION.md`
- `docs/contracts/GIGS_CONTRACT.md` (from `dd027a7`)

**Risk + rollback**

Risk level: **Low**

Rollback plan: Revert merge on `main`, or revert `bf14b50` / `dd027a7` on `develop` if issues appear before merge.
