### PR TITLE
fix(ui): extend oklch tokens and lifted shells across dashboards and admin

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,21 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: OKLCH + frosted pass — dashboards, admin, loading shells (April 11, 2026)**
+
+**UI / DESIGN SYSTEM** — April 11, 2026
+- ✅ **Token typography:** Replaced ad hoc **`text-gray-*`** with **`--oklch-text-*`** across Career Builder dashboard tabs, talent dashboard copy, public **`/gigs`** hero, client gigs results, signup, profile admin empty state, settings client-details labels, admin gigs empty state, and shared **`SecondaryActionLink`** / **`FiltersSheet`** chrome.
+- ✅ **Admin create opportunity:** **`CreateGigForm`** uses **`page-ambient`**, frosted main panel, **`bg-white/5`** inputs/selects, and glass reference-link blocks (no flat gray-800 slab).
+- ✅ **Admin moderation:** Queue/table/filter chrome and **review dialog** use dark frosted panels + oklch text (removed light gray-50 dialog islands); outer shell uses **`oklch-bg`** + ambient.
+- ✅ **Loading alignment:** **`ClientDashboardSkeleton`** wraps **`PageShell ambientTone="lifted"`** (matches live Career Builder shell); **`app/settings/loading.tsx`** uses **`PageShell` + `grain-texture`** and **`panel-frosted`** placeholders.
+- ✅ **Breadth:** Client bookings/applications/gigs surfaces and talent dashboard loading in this batch stay consistent with lifted/frosted language.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — all green (ship run, April 11, 2026).
+
+**Next (P0):** Merge **develop → main** via PR; smoke **admin/gigs/create**, **admin/moderation**, **client/dashboard** loading handoff, **settings** loading, and **talent/dashboard** on staging/production.
+
+**Next (P1):** **`settings/sections/client-details.tsx`** card shell still uses legacy gray inputs—optional full frosted pass; **`talent/settings/billing/loading.tsx`** could mirror **`settings/loading`**.
+
 ## 🚀 **Latest: Application flows — lifted ambient + glass (April 10, 2026)**
 
 **UI / VIZB** — April 10, 2026

--- a/app/admin/gigs/admin-gigs-client.tsx
+++ b/app/admin/gigs/admin-gigs-client.tsx
@@ -113,7 +113,7 @@ export function AdminGigsClient({ gigs: initialGigs, user }: AdminGigsClientProp
             <Briefcase className="h-7 w-7 text-blue-400" />
           </div>
           <h3 className="text-lg font-semibold text-white">No Opportunities Found</h3>
-          <p className="mt-2 text-sm text-gray-400">
+          <p className="mt-2 text-sm text-[var(--oklch-text-tertiary)]">
             {searchQuery || locationFilter !== "all"
               ? "Try adjusting your search or filters."
               : "No opportunities have been posted yet."}

--- a/app/admin/gigs/create/create-gig-form.tsx
+++ b/app/admin/gigs/create/create-gig-form.tsx
@@ -98,21 +98,23 @@ export function CreateGigForm() {
   };
 
   return (
-    <div className="min-h-screen bg-black">
+    <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient text-[var(--oklch-text-primary)]">
       <div className="container mx-auto px-4 py-12">
         <Link
           href="/admin/dashboard"
-          className="inline-flex items-center text-gray-300 hover:text-white mb-8 transition-colors"
+          className="mb-8 inline-flex items-center text-[var(--oklch-text-secondary)] transition-colors hover:text-[var(--oklch-text-primary)]"
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to dashboard
         </Link>
 
-        <div className="max-w-4xl mx-auto bg-gray-900 border border-gray-800 rounded-xl shadow-sm overflow-hidden">
+        <div className="mx-auto max-w-4xl overflow-hidden rounded-2xl border border-border/40 bg-card/25 shadow-sm backdrop-blur-md">
           <div className="p-8">
             <div className="mb-8">
-              <h1 className="text-2xl font-bold mb-2 text-white">Create a New Opportunity</h1>
-              <p className="text-gray-300">
+              <h1 className="mb-2 text-2xl font-bold text-[var(--oklch-text-primary)]">
+                Create a New Opportunity
+              </h1>
+              <p className="text-[var(--oklch-text-secondary)]">
                 Fill out the form below to create a new casting call or opportunity. Be as detailed as
                 possible to attract the right talent.
               </p>
@@ -125,40 +127,40 @@ export function CreateGigForm() {
                 </div>
               )}
               <div className="space-y-2">
-                <Label htmlFor="title" className="text-white">Opportunity Title</Label>
+                <Label htmlFor="title" className="text-[var(--oklch-text-primary)]">Opportunity Title</Label>
                 <Input
                   id="title"
                   name="title"
                   placeholder="e.g., Luxury Jewelry Campaign"
-                  className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                  className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                   required
                 />
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="company" className="text-white">Company/Brand Name</Label>
+                <Label htmlFor="company" className="text-[var(--oklch-text-primary)]">Company/Brand Name</Label>
                 <Input
                   id="company"
                   name="company"
                   placeholder="Your company or brand name"
                   defaultValue="Admin Company"
-                  className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                  className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                 />
               </div>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-2">
-                  <Label htmlFor="category" className="text-white">Opportunity Type</Label>
+                  <Label htmlFor="category" className="text-[var(--oklch-text-primary)]">Opportunity Type</Label>
                   <Select value={category} onValueChange={setCategory}>
                     <SelectTrigger 
                       id="category"
-                      className="bg-gray-800 border-gray-700 text-white data-[placeholder]:text-gray-500"
+                      className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] data-[placeholder]:text-[var(--oklch-text-muted)]"
                     >
                       <SelectValue placeholder="Select opportunity type" />
                     </SelectTrigger>
-                    <SelectContent className="bg-gray-800 border-gray-700 text-white">
+                    <SelectContent className="border-border/40 bg-card/95 text-[var(--oklch-text-primary)] backdrop-blur-md">
                       {VISIBLE_GIG_CATEGORIES.map((cat) => (
-                        <SelectItem key={cat} value={cat} className="text-white focus:bg-gray-700 focus:text-white">
+                        <SelectItem key={cat} value={cat} className="focus:bg-white/10 focus:text-[var(--oklch-text-primary)]">
                           {getCategoryLabel(cat)}
                         </SelectItem>
                       ))}
@@ -167,17 +169,17 @@ export function CreateGigForm() {
                   <input type="hidden" name="category" value={category} />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="location" className="text-white">Location</Label>
+                  <Label htmlFor="location" className="text-[var(--oklch-text-primary)]">Location</Label>
                   <div className="relative">
                     <MapPin
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
                       size={16}
                     />
                     <Input
                       id="location"
                       name="location"
                       placeholder="e.g., New York, NY"
-                      className="pl-9 bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                      className="border-border/40 bg-white/5 pl-9 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                       required
                     />
                   </div>
@@ -185,38 +187,38 @@ export function CreateGigForm() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="description" className="text-white">Description</Label>
+                <Label htmlFor="description" className="text-[var(--oklch-text-primary)]">Description</Label>
                 <Textarea
                   id="description"
                   name="description"
                   placeholder="Describe the opportunity, requirements, and what you're looking for..."
                   rows={4}
-                  className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                  className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                   required
                 />
               </div>
 
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
                 <div className="space-y-2">
-                  <Label htmlFor="start_date" className="text-white">Start Date</Label>
+                  <Label htmlFor="start_date" className="text-[var(--oklch-text-primary)]">Start Date</Label>
                   <div className="relative">
                     <Calendar
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
                       size={16}
                     />
                     <Input 
                       id="start_date" 
                       name="start_date" 
                       type="date" 
-                      className="pl-9 bg-gray-800 border-gray-700 text-white" 
+                      className="border-border/40 bg-white/5 pl-9 text-[var(--oklch-text-primary)]" 
                     />
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="compensation_min" className="text-white">Min Compensation</Label>
+                  <Label htmlFor="compensation_min" className="text-[var(--oklch-text-primary)]">Min Compensation</Label>
                   <div className="relative">
                     <DollarSign
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
                       size={16}
                     />
                     <Input
@@ -224,15 +226,15 @@ export function CreateGigForm() {
                       name="compensation_min"
                       type="number"
                       placeholder="0"
-                      className="pl-9 bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                      className="border-border/40 bg-white/5 pl-9 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                     />
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="compensation_max" className="text-white">Max Compensation</Label>
+                  <Label htmlFor="compensation_max" className="text-[var(--oklch-text-primary)]">Max Compensation</Label>
                   <div className="relative">
                     <DollarSign
-                      className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
                       size={16}
                     />
                     <Input
@@ -240,17 +242,17 @@ export function CreateGigForm() {
                       name="compensation_max"
                       type="number"
                       placeholder="1000"
-                      className="pl-9 bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                      className="border-border/40 bg-white/5 pl-9 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                     />
                   </div>
                 </div>
               </div>
 
-              <div className="space-y-4 rounded-lg border border-gray-700/80 bg-gray-800/40 p-4">
+              <div className="space-y-4 rounded-xl border border-border/40 bg-card/20 p-4 backdrop-blur-sm">
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                   <div>
-                    <Label className="text-base text-white">Reference links (optional)</Label>
-                    <p className="text-sm text-gray-400">
+                    <Label className="text-base text-[var(--oklch-text-primary)]">Reference links (optional)</Label>
+                    <p className="text-sm text-[var(--oklch-text-tertiary)]">
                       Company site, reels, social, portfolio—help talent see the vibe. Up to {MAX_REFERENCE_LINKS}{" "}
                       links, http(s) only.
                     </p>
@@ -261,23 +263,23 @@ export function CreateGigForm() {
                     size="sm"
                     onClick={addReferenceLinkRow}
                     disabled={referenceLinks.length >= MAX_REFERENCE_LINKS || state?.success === true}
-                    className="shrink-0 border-gray-600 text-gray-200 hover:bg-gray-800"
+                    className="shrink-0 border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                   >
                     <Plus className="mr-1 h-4 w-4" />
                     Add link
                   </Button>
                 </div>
                 {referenceLinks.length === 0 ? (
-                  <p className="text-sm text-gray-500">No reference links yet.</p>
+                  <p className="text-sm text-[var(--oklch-text-muted)]">No reference links yet.</p>
                 ) : (
                   <ul className="space-y-4">
                     {referenceLinks.map((row, idx) => (
                       <li
                         key={idx}
-                        className="grid grid-cols-1 gap-3 rounded-md border border-gray-700/60 bg-gray-900/50 p-3 md:grid-cols-12 md:items-end"
+                        className="grid grid-cols-1 gap-3 rounded-lg border border-border/40 bg-card/30 p-3 md:grid-cols-12 md:items-end"
                       >
                         <div className="md:col-span-5 space-y-2">
-                          <Label htmlFor={`ref-url-${idx}`} className="text-white">
+                          <Label htmlFor={`ref-url-${idx}`} className="text-[var(--oklch-text-primary)]">
                             URL
                           </Label>
                           <Input
@@ -285,11 +287,11 @@ export function CreateGigForm() {
                             placeholder="https://…"
                             value={row.url}
                             onChange={(e) => updateReferenceLink(idx, { url: e.target.value })}
-                            className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                            className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                           />
                         </div>
                         <div className="md:col-span-4 space-y-2">
-                          <Label htmlFor={`ref-label-${idx}`} className="text-white">
+                          <Label htmlFor={`ref-label-${idx}`} className="text-[var(--oklch-text-primary)]">
                             Label
                           </Label>
                           <Input
@@ -297,11 +299,11 @@ export function CreateGigForm() {
                             placeholder="e.g. Brand reel"
                             value={row.label}
                             onChange={(e) => updateReferenceLink(idx, { label: e.target.value })}
-                            className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                            className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                           />
                         </div>
                         <div className="md:col-span-2 space-y-2">
-                          <Label htmlFor={`ref-kind-${idx}`} className="text-white">
+                          <Label htmlFor={`ref-kind-${idx}`} className="text-[var(--oklch-text-primary)]">
                             Type
                           </Label>
                           <Select
@@ -314,13 +316,13 @@ export function CreateGigForm() {
                           >
                             <SelectTrigger
                               id={`ref-kind-${idx}`}
-                              className="bg-gray-800 border-gray-700 text-white data-[placeholder]:text-gray-500"
+                              className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] data-[placeholder]:text-[var(--oklch-text-muted)]"
                             >
                               <SelectValue placeholder="Select" />
                             </SelectTrigger>
-                            <SelectContent className="bg-gray-800 border-gray-700 text-white">
+                            <SelectContent className="border-border/40 bg-card/95 text-[var(--oklch-text-primary)] backdrop-blur-md">
                               {GIG_REFERENCE_LINK_KINDS.map((k) => (
-                                <SelectItem key={k} value={k} className="focus:bg-gray-700 focus:text-white">
+                                <SelectItem key={k} value={k} className="focus:bg-white/10 focus:text-[var(--oklch-text-primary)]">
                                   {referenceLinkKindLabel(k)}
                                 </SelectItem>
                               ))}
@@ -334,7 +336,7 @@ export function CreateGigForm() {
                             size="icon"
                             onClick={() => removeReferenceLinkRow(idx)}
                             disabled={state?.success === true}
-                            className="text-rose-400 hover:bg-gray-800 hover:text-rose-300"
+                            className="text-rose-400 hover:bg-white/10 hover:text-rose-300"
                             aria-label="Remove link"
                           >
                             <Trash2 className="h-4 w-4" />
@@ -347,7 +349,7 @@ export function CreateGigForm() {
               </div>
 
               <div className="space-y-4">
-                <Label className="text-white">Requirements</Label>
+                <Label className="text-[var(--oklch-text-primary)]">Requirements</Label>
                 {requirements.map((requirement, index) => (
                   <div key={index} className="flex space-x-2">
                     <Input
@@ -355,7 +357,7 @@ export function CreateGigForm() {
                       placeholder="e.g., Female, 18-25, athletic build"
                       value={requirement}
                       onChange={(e) => updateRequirement(index, e.target.value)}
-                      className="bg-gray-800 border-gray-700 text-white placeholder:text-gray-500"
+                      className="border-border/40 bg-white/5 text-[var(--oklch-text-primary)] placeholder:text-[var(--oklch-text-muted)]"
                     />
                     {requirements.length > 1 && (
                       <Button
@@ -363,7 +365,7 @@ export function CreateGigForm() {
                         variant="outline"
                         size="icon"
                         onClick={() => removeRequirement(index)}
-                        className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
+                        className="border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                       >
                         <Minus size={16} />
                       </Button>
@@ -374,7 +376,7 @@ export function CreateGigForm() {
                   type="button" 
                   variant="outline" 
                   onClick={addRequirement} 
-                  className="w-full border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
+                  className="w-full border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                 >
                   <Plus className="mr-2 h-4 w-4" />
                   Add Requirement
@@ -385,18 +387,18 @@ export function CreateGigForm() {
                 <Switch 
                   id="urgent" 
                   name="urgent"
-                  className="data-[state=checked]:bg-blue-600 data-[state=unchecked]:bg-gray-700"
+                  className="data-[state=checked]:bg-blue-600 data-[state=unchecked]:bg-white/20"
                 />
-                <Label htmlFor="urgent" className="text-white">Mark as urgent</Label>
+                <Label htmlFor="urgent" className="text-[var(--oklch-text-primary)]">Mark as urgent</Label>
               </div>
 
               <div className="flex items-center space-x-2">
                 <Switch 
                   id="featured" 
                   name="featured"
-                  className="data-[state=checked]:bg-blue-600 data-[state=unchecked]:bg-gray-700"
+                  className="data-[state=checked]:bg-blue-600 data-[state=unchecked]:bg-white/20"
                 />
-                <Label htmlFor="featured" className="text-white">Feature this gig</Label>
+                <Label htmlFor="featured" className="text-[var(--oklch-text-primary)]">Feature this gig</Label>
               </div>
 
               {/* Gig Cover Image Upload */}
@@ -412,7 +414,7 @@ export function CreateGigForm() {
                   type="button" 
                   variant="outline" 
                   asChild
-                  className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
+                  className="border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                 >
                   <Link href="/admin/dashboard">Cancel</Link>
                 </Button>

--- a/app/admin/moderation/admin-moderation-client.tsx
+++ b/app/admin/moderation/admin-moderation-client.tsx
@@ -47,7 +47,10 @@ const STATUS_META: Record<FlagStatus, { label: string; badgeClass: string }> = {
   open: { label: "Open", badgeClass: "bg-red-500/15 text-red-400 border-red-500/30" },
   in_review: { label: "In Review", badgeClass: "bg-amber-500/15 text-amber-400 border-amber-500/30" },
   resolved: { label: "Resolved", badgeClass: "bg-green-500/15 text-green-400 border-green-500/30" },
-  dismissed: { label: "Dismissed", badgeClass: "bg-gray-500/15 text-gray-400 border-gray-500/30" },
+  dismissed: {
+    label: "Dismissed",
+    badgeClass: "border-white/20 bg-white/10 text-[var(--oklch-text-tertiary)]",
+  },
 };
 
 const RESOURCE_META: Record<FlagResourceType, { label: string; badgeClass: string }> = {
@@ -143,7 +146,7 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
   };
 
   return (
-    <div className="bg-gradient-to-br from-gray-900 via-black to-gray-900 min-h-screen">
+    <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient text-[var(--oklch-text-primary)]">
       <AdminHeader user={user} />
       <div className="container mx-auto px-4 py-4 sm:py-6">
         {notice && (
@@ -156,10 +159,10 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
         )}
         <div className="mb-4 md:hidden">
           <details>
-            <summary className="cursor-pointer list-none text-sm font-medium text-gray-300">
+            <summary className="cursor-pointer list-none text-sm font-medium text-[var(--oklch-text-secondary)]">
               <span className="inline-flex items-center gap-2">
                 Show stats
-                <span className="text-xs text-gray-500">({stats.total} total)</span>
+                <span className="text-xs text-[var(--oklch-text-muted)]">({stats.total} total)</span>
               </span>
             </summary>
             <div className="mt-2">
@@ -176,38 +179,40 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
         </div>
 
         <div className="mb-6 hidden gap-4 md:mb-8 md:grid md:grid-cols-2 lg:grid-cols-4">
-          <Card className="min-w-0 bg-gray-800/40 border-gray-700">
+          <Card className="panel-frosted min-w-0 border-border/40">
             <CardHeader className="pb-2">
-              <CardDescription>Total Reports</CardDescription>
-              <CardTitle className="text-3xl text-white">{stats.total}</CardTitle>
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">Total Reports</CardDescription>
+              <CardTitle className="text-3xl text-[var(--oklch-text-primary)]">{stats.total}</CardTitle>
             </CardHeader>
           </Card>
           <Card className="min-w-0 bg-red-950/30 border-red-900/50">
             <CardHeader className="pb-2">
-              <CardDescription>Open</CardDescription>
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">Open</CardDescription>
               <CardTitle className="text-3xl text-red-200">{stats.byStatus.open}</CardTitle>
             </CardHeader>
           </Card>
           <Card className="min-w-0 bg-amber-900/30 border-amber-900/40">
             <CardHeader className="pb-2">
-              <CardDescription>In Review</CardDescription>
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">In Review</CardDescription>
               <CardTitle className="text-3xl text-amber-100">{stats.byStatus.in_review}</CardTitle>
             </CardHeader>
           </Card>
           <Card className="min-w-0 bg-emerald-900/30 border-emerald-900/40">
             <CardHeader className="pb-2">
-              <CardDescription>Resolved</CardDescription>
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">Resolved</CardDescription>
               <CardTitle className="text-3xl text-emerald-100">{stats.byStatus.resolved}</CardTitle>
             </CardHeader>
           </Card>
         </div>
 
-          <Card>
+        <Card className="border-border/40 bg-card/25 backdrop-blur-md">
           <CardHeader>
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
               <div>
-                <CardTitle className="text-white">Moderation Queue</CardTitle>
-                <CardDescription>Review reported gigs and take action</CardDescription>
+                <CardTitle className="text-[var(--oklch-text-primary)]">Moderation Queue</CardTitle>
+                <CardDescription className="text-[var(--oklch-text-tertiary)]">
+                  Review reported gigs and take action
+                </CardDescription>
               </div>
               <div className="flex flex-wrap gap-2">
                 {(["all", "open", "in_review", "resolved", "dismissed"] as const).map((key) => {
@@ -219,7 +224,7 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                       className={
                         activeTab === key
                           ? "bg-white text-black"
-                          : "border-gray-600 text-gray-300 hover:text-white"
+                          : "border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                       }
                       onClick={() => setActiveTab(key)}
                     >
@@ -233,37 +238,37 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
           </CardHeader>
           <CardContent className="p-0">
             {filteredFlags.length === 0 ? (
-              <div className="text-center py-16 text-gray-400">No reports in this bucket.</div>
+              <div className="py-16 text-center text-[var(--oklch-text-tertiary)]">No reports in this bucket.</div>
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full">
                   <thead>
-                    <tr className="bg-gray-800">
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                    <tr className="bg-card/40">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Resource
                       </th>
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Reporter
                       </th>
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Reason
                       </th>
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Status
                       </th>
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Created
                       </th>
-                      <th className="text-left text-xs font-medium text-gray-300 uppercase tracking-wider py-4 px-6">
+                      <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-tertiary)]">
                         Actions
                       </th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-border/40">
                     {filteredFlags.map((flag) => (
-                      <tr key={flag.id} className="hover:bg-gray-800/60 text-sm text-gray-200">
+                      <tr key={flag.id} className="text-sm text-[var(--oklch-text-secondary)] hover:bg-white/5">
                         <td className="py-4 px-6">
-                          <div className="font-medium">
+                          <div className="font-medium text-[var(--oklch-text-primary)]">
                             {flag.gig?.title ??
                               flag.target_profile?.display_name ??
                               `${flag.resource_type} ${flag.resource_id}`}
@@ -272,7 +277,9 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                             <Badge className={`border ${RESOURCE_META[flag.resource_type].badgeClass}`}>
                               {RESOURCE_META[flag.resource_type].label}
                             </Badge>
-                            {flag.gig?.location && <span className="text-gray-400">{flag.gig.location}</span>}
+                            {flag.gig?.location && (
+                              <span className="text-[var(--oklch-text-tertiary)]">{flag.gig.location}</span>
+                            )}
                           </div>
                         </td>
                         <td className="py-4 px-6">
@@ -293,7 +300,7 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                           <Button
                             size="sm"
                             variant="outline"
-                            className="border-gray-600 text-gray-200 hover:text-white"
+                            className="border-white/15 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-[var(--oklch-text-primary)]"
                             onClick={() => setSelectedFlag(flag)}
                           >
                             Review
@@ -310,7 +317,7 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
       </div>
 
       <Dialog open={!!selectedFlag} onOpenChange={(open) => !open && setSelectedFlag(null)}>
-        <DialogContent className="max-w-2xl">
+        <DialogContent className="max-w-2xl border-border/40 bg-card/95 text-[var(--oklch-text-primary)] backdrop-blur-md">
           {selectedFlag && (
             <>
               <DialogHeader>
@@ -324,34 +331,36 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
               </DialogHeader>
 
               <div className="grid gap-6">
-                <div className="rounded-xl border border-gray-200 p-4 bg-gray-50">
-                  <p className="text-xs uppercase tracking-wide text-gray-500 mb-2">Reason</p>
-                  <p className="text-gray-900 font-medium">{selectedFlag.reason}</p>
+                <div className="rounded-xl border border-border/40 bg-card/30 p-4">
+                  <p className="mb-2 text-xs uppercase tracking-wide text-[var(--oklch-text-tertiary)]">Reason</p>
+                  <p className="font-medium text-[var(--oklch-text-primary)]">{selectedFlag.reason}</p>
                   {selectedFlag.details && (
-                    <p className="mt-2 text-sm text-gray-700 whitespace-pre-line">
+                    <p className="mt-2 whitespace-pre-line text-sm text-[var(--oklch-text-secondary)]">
                       {selectedFlag.details}
                     </p>
                   )}
                 </div>
 
                 {selectedFlag.gig && (
-                  <div className="rounded-xl border border-gray-200 p-4">
-                    <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Gig</p>
-                    <p className="font-semibold text-gray-900">{selectedFlag.gig.title}</p>
-                    <p className="text-sm text-gray-600">{selectedFlag.gig.location}</p>
-                    <p className="text-sm text-gray-600">
+                  <div className="rounded-xl border border-border/40 bg-card/30 p-4">
+                    <p className="mb-1 text-xs uppercase tracking-wide text-[var(--oklch-text-tertiary)]">Gig</p>
+                    <p className="font-semibold text-[var(--oklch-text-primary)]">{selectedFlag.gig.title}</p>
+                    <p className="text-sm text-[var(--oklch-text-secondary)]">{selectedFlag.gig.location}</p>
+                    <p className="text-sm text-[var(--oklch-text-secondary)]">
                       Client: {selectedFlag.gig.client_profile?.display_name || "N/A"}
                     </p>
                   </div>
                 )}
 
                 {selectedFlag.target_profile && (
-                  <div className="rounded-xl border border-gray-200 p-4 space-y-1">
-                    <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Account</p>
-                    <p className="font-semibold text-gray-900">
+                  <div className="space-y-1 rounded-xl border border-border/40 bg-card/30 p-4">
+                    <p className="mb-1 text-xs uppercase tracking-wide text-[var(--oklch-text-tertiary)]">Account</p>
+                    <p className="font-semibold text-[var(--oklch-text-primary)]">
                       {selectedFlag.target_profile.display_name || "Unknown user"}
                     </p>
-                    <p className="text-sm text-gray-600">Role: {selectedFlag.target_profile.role || "N/A"}</p>
+                    <p className="text-sm text-[var(--oklch-text-secondary)]">
+                      Role: {selectedFlag.target_profile.role || "N/A"}
+                    </p>
                     {selectedFlag.target_profile.is_suspended && (
                       <p className="text-sm text-rose-600">
                         Currently suspended
@@ -396,12 +405,12 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                 </div>
 
                 {(selectedFlag.gig || selectedFlag.target_profile) && (
-                  <div className="rounded-xl border border-gray-200 p-4 space-y-4">
-                    <Label className="text-sm font-semibold text-gray-800">Automations</Label>
+                  <div className="space-y-4 rounded-xl border border-border/40 bg-card/30 p-4">
+                    <Label className="text-sm font-semibold text-[var(--oklch-text-primary)]">Automations</Label>
                     <div className="flex items-center justify-between">
                       <div>
-                        <p className="font-medium text-gray-900">Close this gig</p>
-                        <p className="text-sm text-gray-600">
+                        <p className="font-medium text-[var(--oklch-text-primary)]">Close this gig</p>
+                        <p className="text-sm text-[var(--oklch-text-secondary)]">
                           Sets gig status to closed and removes it from listings.
                         </p>
                       </div>
@@ -409,8 +418,8 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                     </div>
                     <div className="flex items-center justify-between">
                       <div className="flex-1">
-                        <p className="font-medium text-gray-900">Suspend account</p>
-                        <p className="text-sm text-gray-600">
+                        <p className="font-medium text-[var(--oklch-text-primary)]">Suspend account</p>
+                        <p className="text-sm text-[var(--oklch-text-secondary)]">
                           Prevents the account from signing in until reinstated.
                         </p>
                       </div>
@@ -437,10 +446,12 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
                       </div>
                     )}
                     {selectedFlag.target_profile?.is_suspended && (
-                      <div className="flex items-center justify-between border-t border-gray-200 pt-3">
+                      <div className="flex items-center justify-between border-t border-border/40 pt-3">
                         <div>
-                          <p className="font-medium text-gray-900">Reinstate account</p>
-                          <p className="text-sm text-gray-600">Lift the current suspension immediately.</p>
+                          <p className="font-medium text-[var(--oklch-text-primary)]">Reinstate account</p>
+                          <p className="text-sm text-[var(--oklch-text-secondary)]">
+                            Lift the current suspension immediately.
+                          </p>
                         </div>
                         <Switch
                           checked={reinstateAccount}
@@ -458,7 +469,7 @@ export function AdminModerationClient({ flags, user, notice }: AdminModerationCl
               </div>
 
               <DialogFooter className="flex flex-col gap-3 sm:flex-row sm:justify-between">
-                <div className="flex items-center gap-2 text-sm text-gray-600">
+                <div className="flex items-center gap-2 text-sm text-[var(--oklch-text-tertiary)]">
                   {STATUS_META[selectedFlag.status].label}
                   {selectedFlag.status === "resolved" && <BadgeCheck className="h-4 w-4 text-green-500" />}
                 </div>

--- a/app/client/applications/client-applications-client.tsx
+++ b/app/client/applications/client-applications-client.tsx
@@ -14,6 +14,7 @@ import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { getClientApplications } from "@/lib/actions/client-applications-actions";
 
 const AcceptApplicationDialog = dynamic(
@@ -203,7 +204,7 @@ export default function ClientApplicationsClient({
     `/talent/${application.talent_id}`;
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
       <ClientTerminalHeader
         title="Applications"
         subtitle="Review and manage talent applications for your opportunities"
@@ -485,6 +486,6 @@ export default function ClientApplicationsClient({
           />
         </>
       )}
-    </div>
+    </TotlAtmosphereShell>
   );
 }

--- a/app/client/bookings/client-bookings-client.tsx
+++ b/app/client/bookings/client-bookings-client.tsx
@@ -14,6 +14,7 @@ import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { cancelBooking, getClientBookings, updateBookingStatus } from "@/lib/actions/booking-actions";
 import { logger } from "@/lib/utils/logger";
 import type { Database } from "@/types/supabase";
@@ -136,38 +137,44 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-black px-4 py-8">
-        <div className="mx-auto w-full max-w-6xl space-y-6">
-          <div className="space-y-3">
-            <Skeleton className="h-9 w-56 bg-zinc-800/70" />
-            <Skeleton className="h-4 w-72 max-w-full bg-zinc-800/60" />
+      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+        <div className="px-4 py-8">
+          <div className="mx-auto w-full max-w-6xl space-y-6">
+            <div className="space-y-3">
+              <Skeleton className="h-9 w-56 rounded-lg bg-muted/40" />
+              <Skeleton className="h-4 w-72 max-w-full rounded-lg bg-muted/35" />
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+            </div>
+            <Skeleton className="h-[420px] w-full rounded-xl bg-muted/35" />
           </div>
-          <div className="grid gap-4 md:grid-cols-3">
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-          </div>
-          <Skeleton className="h-[420px] w-full rounded-xl bg-zinc-800/60" />
         </div>
-      </div>
+      </TotlAtmosphereShell>
     );
   }
 
   if (error) {
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-center max-w-md mx-auto p-6">
-          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-white mb-2">Error</h2>
-          <p className="text-gray-300 mb-4">{error instanceof Error ? error.message : "Failed to load bookings"}</p>
-          <Button onClick={() => mutate()}>Try Again</Button>
+      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+        <div className="flex min-h-[100dvh] items-center justify-center px-4">
+          <div className="panel-frosted card-backlit max-w-md rounded-2xl p-8 text-center">
+            <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-400" />
+            <h2 className="mb-2 text-xl font-semibold">Error</h2>
+            <p className="mb-4 text-[var(--oklch-text-muted)]">
+              {error instanceof Error ? error.message : "Failed to load bookings"}
+            </p>
+            <Button onClick={() => mutate()}>Try Again</Button>
+          </div>
         </div>
-      </div>
+      </TotlAtmosphereShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
       <ClientTerminalHeader
         title="Bookings"
         subtitle="Manage your confirmed talent bookings"
@@ -191,7 +198,7 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
           <MobileTabRail>
-            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-xl border border-gray-800 bg-gray-900 p-1">
+            <TabsList className="tabs-list-surface inline-flex h-auto min-w-max gap-1 rounded-xl p-1">
               <TabsTrigger value="all" className="min-h-10 whitespace-nowrap px-3 py-2 text-xs">
                 All ({bookingStats.total})
               </TabsTrigger>
@@ -209,7 +216,7 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
               </TabsTrigger>
             </TabsList>
           </MobileTabRail>
-          <TabsList className="hidden w-full grid-cols-5 md:grid">
+          <TabsList className="tabs-list-surface hidden w-full grid-cols-5 md:grid">
             <TabsTrigger value="all">All ({bookingStats.total})</TabsTrigger>
             <TabsTrigger value="pending">Pending ({bookingStats.pending})</TabsTrigger>
             <TabsTrigger value="confirmed">Confirmed ({bookingStats.confirmed})</TabsTrigger>
@@ -227,6 +234,6 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
           </TabsContent>
         </Tabs>
       </div>
-    </div>
+    </TotlAtmosphereShell>
   );
 }

--- a/app/client/bookings/components/bookings-results-content.tsx
+++ b/app/client/bookings/components/bookings-results-content.tsx
@@ -23,11 +23,11 @@ export default function BookingsResultsContent({
 }: BookingsResultsContentProps) {
   if (filteredBookings.length === 0) {
     return (
-      <Card className="border-gray-700 bg-gray-900">
+      <Card>
         <CardContent className="p-12 text-center">
-          <Calendar className="mx-auto mb-4 h-12 w-12 text-gray-400" />
-          <h3 className="mb-2 text-lg font-medium text-white">No bookings found</h3>
-          <p className="mb-6 text-gray-300">
+          <Calendar className="mx-auto mb-4 h-12 w-12 text-[var(--oklch-text-muted)]" />
+          <h3 className="mb-2 text-lg font-medium">No bookings found</h3>
+          <p className="mb-6 text-[var(--oklch-text-secondary)]">
             {activeTab === "all"
               ? "Accept applications to create bookings"
               : `No ${activeTab} bookings at the moment`}
@@ -43,12 +43,12 @@ export default function BookingsResultsContent({
   return (
     <div className="space-y-4">
       {filteredBookings.map((booking) => (
-        <Card key={booking.id} className="border-gray-700 bg-gray-900 transition-shadow hover:shadow-md">
+        <Card key={booking.id} className="transition-shadow hover:shadow-md">
           <CardHeader>
             <div className="flex items-start justify-between">
               <div className="flex-1">
-                <CardTitle className="mb-2 text-xl text-white">{booking.gigs?.title}</CardTitle>
-                <div className="flex flex-wrap items-center gap-4 text-sm text-gray-300">
+                <CardTitle className="mb-2 text-xl">{booking.gigs?.title}</CardTitle>
+                <div className="flex flex-wrap items-center gap-4 text-sm text-[var(--oklch-text-secondary)]">
                   <span className="flex items-center gap-1">
                     <User className="h-4 w-4" />
                     {booking.profiles?.display_name || "Unknown Talent"}
@@ -76,7 +76,7 @@ export default function BookingsResultsContent({
           <CardContent>
             {booking.notes && (
               <div className="panel-frosted mb-4 rounded-md p-3">
-                <p className="text-sm text-gray-300">
+                <p className="text-sm text-[var(--oklch-text-secondary)]">
                   <FileText className="mr-2 inline h-4 w-4" />
                   {booking.notes}
                 </p>

--- a/app/client/bookings/components/bookings-stats-overview.tsx
+++ b/app/client/bookings/components/bookings-stats-overview.tsx
@@ -19,10 +19,10 @@ export default function BookingsStatsOverview({ stats }: BookingsStatsOverviewPr
     <>
       <div className="mb-4 md:hidden">
         <details>
-          <summary className="cursor-pointer list-none text-sm font-medium text-gray-300">
+          <summary className="cursor-pointer list-none text-sm font-medium text-[var(--oklch-text-secondary)]">
             <span className="inline-flex items-center gap-2">
               Show stats
-              <span className="text-xs text-gray-500">({stats.total} total)</span>
+              <span className="text-xs text-[var(--oklch-text-muted)]">({stats.total} total)</span>
             </span>
           </summary>
           <div className="mt-2">
@@ -40,60 +40,60 @@ export default function BookingsStatsOverview({ stats }: BookingsStatsOverviewPr
       </div>
 
       <div className="mb-8 hidden gap-4 md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Total</p>
-                <p className="text-2xl font-bold text-white">{stats.total}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Total</p>
+                <p className="text-2xl font-bold">{stats.total}</p>
               </div>
-              <Calendar className="h-8 w-8 text-gray-400" />
+              <Calendar className="h-8 w-8 text-[var(--oklch-text-muted)]" />
             </div>
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Pending</p>
-                <p className="text-2xl font-bold text-white">{stats.pending}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Pending</p>
+                <p className="text-2xl font-bold">{stats.pending}</p>
               </div>
               <Clock className="h-8 w-8 text-yellow-400" />
             </div>
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Confirmed</p>
-                <p className="text-2xl font-bold text-white">{stats.confirmed}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Confirmed</p>
+                <p className="text-2xl font-bold">{stats.confirmed}</p>
               </div>
               <CheckCircle2 className="h-8 w-8 text-green-400" />
             </div>
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Completed</p>
-                <p className="text-2xl font-bold text-white">{stats.completed}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Completed</p>
+                <p className="text-2xl font-bold">{stats.completed}</p>
               </div>
               <CheckCircle2 className="h-8 w-8 text-blue-400" />
             </div>
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Cancelled</p>
-                <p className="text-2xl font-bold text-white">{stats.cancelled}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Cancelled</p>
+                <p className="text-2xl font-bold">{stats.cancelled}</p>
               </div>
               <XCircle className="h-8 w-8 text-red-400" />
             </div>

--- a/app/client/dashboard/client.tsx
+++ b/app/client/dashboard/client.tsx
@@ -157,7 +157,11 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
   // Show login prompt if no user
   if (!user) {
     return (
-      <PageShell className="grain-texture glow-backplate text-white" containerClassName="flex min-h-[70vh] items-center justify-center py-8">
+      <PageShell
+        ambientTone="lifted"
+        className="grain-texture glow-backplate text-[var(--oklch-text-primary)]"
+        containerClassName="flex min-h-[70vh] items-center justify-center py-8"
+      >
         <SectionCard className="mx-auto w-full max-w-md text-center">
           <User className="mx-auto mb-6 h-16 w-16 text-[var(--oklch-text-secondary)]" aria-hidden />
           <h2 className="mb-3 text-2xl font-bold text-[var(--oklch-text-primary)]">Welcome back</h2>
@@ -181,12 +185,10 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
     );
   }
 
-  const quickStatCardClass = "text-white";
-  const panelCardClass = "text-white";
   const tabTriggerClass =
-    "flex min-h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg border border-transparent px-3 py-2 text-xs text-gray-200 transition hover:bg-gray-800 data-[state=active]:bg-indigo-600 data-[state=active]:text-white data-[state=active]:shadow-lg sm:text-sm";
+    "flex min-h-10 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-3 py-2 text-xs sm:text-sm";
   return (
-    <PageShell topPadding={false} fullBleed>
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
       <ClientTerminalHeader
         title="Career Builder Dashboard"
         subtitle={clientProfile?.company_name || "Manage opportunities and applications"}
@@ -204,7 +206,7 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
               }
             }}
             disabled={isSigningOut}
-            className="border-gray-700 text-white hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <LogOut className="mr-2 h-4 w-4" />
             {isSigningOut ? "Signing Out..." : "Sign Out"}
@@ -226,7 +228,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4 sm:space-y-6">
           <div className="hidden gap-4 md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6">
             <ClientStatCard
-              className={quickStatCardClass}
               title="Total Opportunities"
               icon={<Briefcase className="h-4 w-4 text-blue-300" />}
               badgeLabel="All time"
@@ -237,7 +238,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
 
             <ClientStatCard
-              className={quickStatCardClass}
               title="Active Opportunities"
               icon={<Activity className="h-4 w-4 text-green-300" />}
               badgeLabel="Live"
@@ -248,7 +248,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
 
             <ClientStatCard
-              className={quickStatCardClass}
               title="Applications"
               icon={<Users className="h-4 w-4 text-purple-300" />}
               badgeLabel="Total"
@@ -259,7 +258,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
 
             <ClientStatCard
-              className={quickStatCardClass}
               title="New"
               icon={<ClockIcon className="h-4 w-4 text-yellow-300" />}
               badgeLabel="Incoming"
@@ -270,7 +268,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
 
             <ClientStatCard
-              className={quickStatCardClass}
               title="Closed"
               icon={<CheckCircle className="h-4 w-4 text-green-300" />}
               badgeLabel="Closed"
@@ -281,7 +278,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
 
             <ClientStatCard
-              className={quickStatCardClass}
               title="Total Spent"
               icon={<DollarSign className="h-4 w-4 text-emerald-300" />}
               badgeLabel="To date"
@@ -292,7 +288,7 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
             />
           </div>
           <MobileTabRail>
-            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-2xl border border-gray-800 bg-gray-900 p-1">
+            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-2xl p-1">
               <TabsTrigger value="overview" className={tabTriggerClass}>
                 <BarChart3 className="h-3.5 w-3.5" />
                 Overview
@@ -311,7 +307,7 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
               </TabsTrigger>
             </TabsList>
           </MobileTabRail>
-          <TabsList className="hidden w-full grid-cols-4 gap-2 rounded-2xl border border-gray-800 bg-gray-900 p-1 md:grid">
+          <TabsList className="hidden w-full grid-cols-4 gap-2 rounded-2xl p-1 md:grid">
             <TabsTrigger value="overview" className={tabTriggerClass}>
               <BarChart3 className="h-4 w-4" />
               Overview
@@ -337,7 +333,6 @@ export function ClientDashboard({ initialData }: ClientDashboardProps) {
               gigs={gigs}
               applications={applications}
               upcomingDeadlines={upcomingDeadlines}
-              panelCardClass={panelCardClass}
               getCategoryColor={getCategoryColor}
             />
           </TabsContent>

--- a/app/client/dashboard/tabs/applications-tab-content.tsx
+++ b/app/client/dashboard/tabs/applications-tab-content.tsx
@@ -22,7 +22,7 @@ export default function ApplicationsTabContent({
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold text-white">Applications</h2>
-          <p className="text-gray-300">Review and manage talent applications for your gigs</p>
+          <p className="text-[var(--oklch-text-secondary)]">Review and manage talent applications for your gigs</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" size="sm">
@@ -53,7 +53,7 @@ export default function ApplicationsTabContent({
             {applications.map((application) => (
               <Card
                 key={application.id}
-                className="border border-gray-800 bg-gray-900/80 text-white transition-shadow hover:shadow-md"
+                className="transition-shadow hover:shadow-md"
               >
                 <CardContent className="p-6">
                   <div className="flex items-center gap-4">
@@ -81,17 +81,17 @@ export default function ApplicationsTabContent({
                               ? `${application.talent_profiles.first_name} ${application.talent_profiles.last_name}`
                               : application.profiles?.display_name || "Talent User"}
                           </h3>
-                          <p className="text-gray-300">{application.gigs?.title}</p>
+                          <p className="text-[var(--oklch-text-secondary)]">{application.gigs?.title}</p>
                           <div className="mt-2 flex items-center gap-4">
-                            <span className="text-sm text-gray-400">
+                            <span className="text-sm text-[var(--oklch-text-tertiary)]">
                               <MapPin className="mr-1 inline h-4 w-4" />
                               {application.talent_profiles?.location || "Location not specified"}
                             </span>
-                            <span className="text-sm text-gray-400">
+                            <span className="text-sm text-[var(--oklch-text-tertiary)]">
                               <Clock className="mr-1 inline h-4 w-4" />
                               {application.talent_profiles?.experience || "Experience not specified"}
                             </span>
-                            <span className="text-sm text-gray-400">
+                            <span className="text-sm text-[var(--oklch-text-tertiary)]">
                               Applied {new Date(application.created_at).toLocaleDateString()}
                             </span>
                             {application.profiles?.email_verified && (
@@ -107,11 +107,11 @@ export default function ApplicationsTabContent({
                     </div>
 
                     <div className="flex gap-2">
-                      <Button variant="outline" size="sm" className="border-gray-700 text-white hover:bg-white/5">
+                      <Button variant="outline" size="sm" className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10">
                         <UserCheck className="mr-2 h-4 w-4" />
                         Review
                       </Button>
-                      <Button variant="outline" size="sm" className="border-gray-700 text-white hover:bg-white/5">
+                      <Button variant="outline" size="sm" className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10">
                         <Phone className="mr-2 h-4 w-4" />
                         Contact
                       </Button>

--- a/app/client/dashboard/tabs/create-tab-content.tsx
+++ b/app/client/dashboard/tabs/create-tab-content.tsx
@@ -12,35 +12,35 @@ export default function CreateTabContent() {
         <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-blue-50">
           <Plus className="h-10 w-10 text-blue-600" />
         </div>
-        <h2 className="mb-4 text-2xl font-bold text-white">Create Your Next Opportunity</h2>
-        <p className="mb-8 text-gray-300">
+        <h2 className="mb-4 text-2xl font-bold text-[var(--oklch-text-primary)]">Create Your Next Opportunity</h2>
+        <p className="mb-8 text-[var(--oklch-text-secondary)]">
           Post a new opportunity to find the perfect talent for your project. Our platform
           connects you with qualified talent and professionals.
         </p>
 
         <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
-          <Card className="border border-gray-800 bg-gray-900/60 p-6 text-center text-white">
+          <Card className="p-6 text-center">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-purple-900/40">
               <FileText className="h-6 w-6 text-purple-300" />
             </div>
-            <h3 className="mb-2 font-semibold text-white">Easy Setup</h3>
-            <p className="text-sm text-gray-400">Fill out a simple form with your project details</p>
+            <h3 className="mb-2 font-semibold text-[var(--oklch-text-primary)]">Easy Setup</h3>
+            <p className="text-sm text-[var(--oklch-text-muted)]">Fill out a simple form with your project details</p>
           </Card>
 
-          <Card className="border border-gray-800 bg-gray-900/60 p-6 text-center text-white">
+          <Card className="p-6 text-center">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-900/40">
               <Users className="h-6 w-6 text-emerald-300" />
             </div>
-            <h3 className="mb-2 font-semibold text-white">Quality Applications</h3>
-            <p className="text-sm text-gray-400">Receive applications from qualified talent</p>
+            <h3 className="mb-2 font-semibold text-[var(--oklch-text-primary)]">Quality Applications</h3>
+            <p className="text-sm text-[var(--oklch-text-muted)]">Receive applications from qualified talent</p>
           </Card>
 
-          <Card className="border border-gray-800 bg-gray-900/60 p-6 text-center text-white">
+          <Card className="p-6 text-center">
             <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-900/40">
               <CheckCircle className="h-6 w-6 text-sky-300" />
             </div>
-            <h3 className="mb-2 font-semibold text-white">Quick Hiring</h3>
-            <p className="text-sm text-gray-400">Review profiles and hire the perfect match</p>
+            <h3 className="mb-2 font-semibold text-[var(--oklch-text-primary)]">Quick Hiring</h3>
+            <p className="text-sm text-[var(--oklch-text-muted)]">Review profiles and hire the perfect match</p>
           </Card>
         </div>
 

--- a/app/client/dashboard/tabs/gigs-tab-content.tsx
+++ b/app/client/dashboard/tabs/gigs-tab-content.tsx
@@ -21,7 +21,7 @@ export default function GigsTabContent({ gigs, getCategoryColor }: GigsTabConten
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold text-white">My Opportunities</h2>
-          <p className="text-gray-300">Manage your posted opportunities and track their performance</p>
+          <p className="text-[var(--oklch-text-secondary)]">Manage your posted opportunities and track their performance</p>
         </div>
         <Button asChild className="bg-gradient-to-br from-blue-600 to-indigo-600 text-white hover:opacity-90">
           <Link href="/client/post-gig">
@@ -35,13 +35,13 @@ export default function GigsTabContent({ gigs, getCategoryColor }: GigsTabConten
         {gigs.map((gig) => (
           <Card
             key={gig.id}
-            className="border border-gray-800 bg-gray-900/80 text-white transition-shadow hover:shadow-lg"
+            className="transition-shadow hover:shadow-lg"
           >
             <CardHeader className="pb-3">
               <div className="flex items-start justify-between">
                 <div className="flex-1">
                   <CardTitle className="text-lg text-white">{gig.title}</CardTitle>
-                  <CardDescription className="mt-1 text-gray-400">{gig.location}</CardDescription>
+                  <CardDescription className="mt-1 text-[var(--oklch-text-tertiary)]">{gig.location}</CardDescription>
                 </div>
                 <Button variant="ghost" size="sm">
                   <MoreVertical className="h-4 w-4" />
@@ -67,33 +67,33 @@ export default function GigsTabContent({ gigs, getCategoryColor }: GigsTabConten
 
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Compensation:</span>
+                  <span className="text-[var(--oklch-text-tertiary)]">Compensation:</span>
                   <span className="font-medium">{gig.compensation}</span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Applications:</span>
+                  <span className="text-[var(--oklch-text-tertiary)]">Applications:</span>
                   <span className="font-medium">{gig.applications_count}</span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Posted:</span>
+                  <span className="text-[var(--oklch-text-tertiary)]">Posted:</span>
                   <span className="font-medium">{gig.created_at}</span>
                 </div>
               </div>
 
               <div className="flex flex-wrap gap-2">
-                <Button variant="outline" size="sm" asChild className="flex-1 min-w-[7rem] border-gray-700 text-white hover:bg-white/5">
+                <Button variant="outline" size="sm" asChild className="flex-1 min-w-[7rem] border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10">
                   <Link href={`/gigs/${gig.id}`}>
                     <Eye className="mr-2 h-4 w-4" />
                     View
                   </Link>
                 </Button>
-                <Button variant="outline" size="sm" asChild className="flex-1 min-w-[7rem] border-gray-700 text-white hover:bg-white/5">
+                <Button variant="outline" size="sm" asChild className="flex-1 min-w-[7rem] border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10">
                   <Link href={`/client/gigs/${gig.id}/edit`} data-testid="edit-gig">
                     <Pencil className="mr-2 h-4 w-4" />
                     Edit
                   </Link>
                 </Button>
-                <Button variant="outline" size="sm" className="flex-1 min-w-[7rem] border-gray-700 text-white hover:bg-white/5">
+                <Button variant="outline" size="sm" className="flex-1 min-w-[7rem] border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10">
                   <Users className="mr-2 h-4 w-4" />
                   Applications
                 </Button>

--- a/app/client/dashboard/tabs/overview-tab-content.tsx
+++ b/app/client/dashboard/tabs/overview-tab-content.tsx
@@ -25,7 +25,6 @@ interface OverviewTabContentProps {
   gigs: DashboardGig[];
   applications: DashboardApplication[];
   upcomingDeadlines: DashboardGig[];
-  panelCardClass: string;
   getCategoryColor: (category: string | undefined) => string;
 }
 
@@ -35,7 +34,6 @@ export default function OverviewTabContent({
   gigs,
   applications,
   upcomingDeadlines,
-  panelCardClass,
   getCategoryColor,
 }: OverviewTabContentProps) {
   return (
@@ -61,7 +59,7 @@ export default function OverviewTabContent({
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         <div className="totl-border-violet totl-hover-glow">
-          <Card className={`${panelCardClass} totl-border-violet-inner`}>
+          <Card className="totl-border-violet-inner">
             <CardHeader>
               <div className="card-header-row">
                 <CardTitle className="flex items-center gap-2 text-white">
@@ -73,7 +71,7 @@ export default function OverviewTabContent({
                   className="status-chip shrink-0 whitespace-nowrap border-[var(--totl-violet-border)]"
                 />
               </div>
-              <CardDescription className="text-gray-400">
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">
                 Your latest gig postings and their status
               </CardDescription>
             </CardHeader>
@@ -94,15 +92,15 @@ export default function OverviewTabContent({
                           />
                           <div className="min-w-0 flex-1 space-y-1">
                             <p className="truncate text-sm font-semibold text-white">{gig.title}</p>
-                            <div className="flex items-center gap-2 text-xs text-gray-400">
+                            <div className="flex items-center gap-2 text-xs text-[var(--oklch-text-tertiary)]">
                               <GigStatusBadge status={gig.status ?? "draft"} />
                               <span>{gig.location}</span>
                             </div>
-                            <p className="text-xs text-gray-400">
+                            <p className="text-xs text-[var(--oklch-text-tertiary)]">
                               {gig.applications_count || 0} applications
                             </p>
                           </div>
-                          <Button variant="ghost" size="icon" className="text-gray-400 hover:bg-card/30">
+                          <Button variant="ghost" size="icon" className="text-[var(--oklch-text-tertiary)] hover:bg-card/30">
                             <ChevronRight className="h-4 w-4" />
                           </Button>
                         </div>
@@ -134,13 +132,13 @@ export default function OverviewTabContent({
                             </Badge>
                             <GigStatusBadge status={gig.status ?? "draft"} />
                           </div>
-                          <p className="mt-1 text-sm text-gray-400">
+                          <p className="mt-1 text-sm text-[var(--oklch-text-tertiary)]">
                             {gig.applications_count || 0} applications - {gig.location}
                           </p>
                         </div>
                         <div className="text-right">
                           <p className="font-medium text-white">{gig.compensation}</p>
-                          <p className="text-sm text-gray-400">{gig.created_at}</p>
+                          <p className="text-sm text-[var(--oklch-text-tertiary)]">{gig.created_at}</p>
                         </div>
                       </div>
                     ))}
@@ -177,7 +175,7 @@ export default function OverviewTabContent({
         </div>
 
         <div className="totl-border-violet totl-hover-glow">
-          <Card className={`${panelCardClass} totl-border-violet-inner`}>
+          <Card className="totl-border-violet-inner">
             <CardHeader>
               <div className="card-header-row">
                 <CardTitle className="flex items-center gap-2 text-white">
@@ -191,12 +189,12 @@ export default function OverviewTabContent({
                   New
                 </Badge>
               </div>
-              <CardDescription className="text-gray-400">
+              <CardDescription className="text-[var(--oklch-text-tertiary)]">
                 Latest talent applications to review
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-[var(--oklch-text-tertiary)]">
                 Clients only see talent who applied to their gigs—no public directory is exposed.
               </p>
               {applications.length > 0 ? (
@@ -212,8 +210,8 @@ export default function OverviewTabContent({
                             <p className="text-sm font-semibold text-white">
                               {application.talent_profiles?.first_name} {application.talent_profiles?.last_name}
                             </p>
-                            <p className="truncate text-xs text-gray-400">{application.gigs?.title}</p>
-                            <div className="flex items-center gap-2 text-xs text-gray-400">
+                            <p className="truncate text-xs text-[var(--oklch-text-tertiary)]">{application.gigs?.title}</p>
+                            <div className="flex items-center gap-2 text-xs text-[var(--oklch-text-tertiary)]">
                               <ApplicationStatusBadge status={application.status} showIcon={false} />
                               <span>{application.talent_profiles?.location}</span>
                             </div>
@@ -230,24 +228,24 @@ export default function OverviewTabContent({
                   </div>
                   <div className="hidden space-y-4 md:block">
                     {applications.slice(0, 3).map((application) => (
-                      <div key={application.id} className="flex items-center gap-4 rounded-lg border border-gray-700 p-3">
+                      <div key={application.id} className="flex items-center gap-4 rounded-lg border border-border/40 p-3">
                         <div className="min-w-0 flex-1">
                           <h4 className="font-medium text-white">
                             {application.talent_profiles?.first_name} {application.talent_profiles?.last_name}
                           </h4>
-                          <p className="truncate text-sm text-gray-400">{application.gigs?.title}</p>
+                          <p className="truncate text-sm text-[var(--oklch-text-tertiary)]">{application.gigs?.title}</p>
                           <div className="mt-1 flex items-center gap-2">
                             <ApplicationStatusBadge status={application.status} showIcon={true} />
-                            <span className="text-sm text-gray-400">
+                            <span className="text-sm text-[var(--oklch-text-tertiary)]">
                               {application.talent_profiles?.location}
                             </span>
                           </div>
                         </div>
                         <div className="text-right">
-                          <p className="text-sm text-gray-400">
+                          <p className="text-sm text-[var(--oklch-text-tertiary)]">
                             {new Date(application.created_at).toLocaleDateString()}
                           </p>
-                          <p className="text-xs text-gray-400">{application.talent_profiles?.experience}</p>
+                          <p className="text-xs text-[var(--oklch-text-tertiary)]">{application.talent_profiles?.experience}</p>
                         </div>
                       </div>
                     ))}
@@ -270,7 +268,7 @@ export default function OverviewTabContent({
       </div>
 
       <div className="totl-border-violet totl-hover-glow">
-        <Card className={`${panelCardClass} totl-border-violet-inner`}>
+        <Card className="totl-border-violet-inner">
           <CardHeader>
             <div className="card-header-row">
               <CardTitle className="flex items-center gap-2">
@@ -293,16 +291,18 @@ export default function OverviewTabContent({
                   {upcomingDeadlines.map((deadline) => (
                     <div
                       key={deadline.id}
-                      className="flex items-center justify-between rounded-lg border border-gray-800 p-4"
+                      className="flex items-center justify-between rounded-lg border border-border/40 bg-card/20 p-4"
                     >
                       <div className="flex-1">
-                        <h4 className="font-medium text-white">{deadline.title}</h4>
-                        <p className="text-sm text-gray-400">
+                        <h4 className="font-medium text-[var(--oklch-text-primary)]">{deadline.title}</h4>
+                        <p className="text-sm text-[var(--oklch-text-muted)]">
                           {deadline.applications_count || 0} applications received
                         </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-medium text-white">Due {deadline.application_deadline}</p>
+                        <p className="font-medium text-[var(--oklch-text-primary)]">
+                          Due {deadline.application_deadline}
+                        </p>
                         <GigStatusBadge status={deadline.status ?? "draft"} />
                       </div>
                     </div>

--- a/app/client/gigs/client.tsx
+++ b/app/client/gigs/client.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { getClientGigs, type ClientGig } from "@/lib/actions/client-gigs-actions";
 
 const GigsStatsOverview = dynamic(() => import("./components/gigs-stats-overview"), { ssr: false });
@@ -111,41 +112,45 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
   // Show error state if Supabase is not configured
   if (error) {
     return (
-      <div className="min-h-screen bg-black flex items-center justify-center">
-        <div className="text-center max-w-md mx-auto p-6">
-          <AlertCircle className="h-12 w-12 text-red-500 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-white mb-2">Unable to load gigs</h2>
-          <p className="text-gray-300 mb-4">
-            {error instanceof Error ? error.message : "Failed to load opportunities"}
-          </p>
-          <Button onClick={() => mutate()}>Try Again</Button>
+      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+        <div className="flex min-h-[100dvh] items-center justify-center px-4">
+          <div className="panel-frosted card-backlit max-w-md rounded-2xl p-8 text-center">
+            <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-400" />
+            <h2 className="mb-2 text-xl font-semibold">Unable to load gigs</h2>
+            <p className="mb-4 text-[var(--oklch-text-muted)]">
+              {error instanceof Error ? error.message : "Failed to load opportunities"}
+            </p>
+            <Button onClick={() => mutate()}>Try Again</Button>
+          </div>
         </div>
-      </div>
+      </TotlAtmosphereShell>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-black px-4 py-8">
-        <div className="mx-auto w-full max-w-6xl space-y-6">
-          <div className="space-y-3">
-            <Skeleton className="h-9 w-56 bg-zinc-800/70" />
-            <Skeleton className="h-4 w-72 max-w-full bg-zinc-800/60" />
+      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+        <div className="px-4 py-8">
+          <div className="mx-auto w-full max-w-6xl space-y-6">
+            <div className="space-y-3">
+              <Skeleton className="h-9 w-56 rounded-lg bg-muted/40" />
+              <Skeleton className="h-4 w-72 max-w-full rounded-lg bg-muted/35" />
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+              <Skeleton className="h-24 w-full rounded-xl bg-muted/35" />
+            </div>
+            <Skeleton className="h-[460px] w-full rounded-xl bg-muted/35" />
           </div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-            <Skeleton className="h-24 w-full rounded-xl bg-zinc-800/60" />
-          </div>
-          <Skeleton className="h-[460px] w-full rounded-xl bg-zinc-800/60" />
         </div>
-      </div>
+      </TotlAtmosphereShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
       <ClientTerminalHeader
         title="My Opportunities"
         subtitle="Manage your posted opportunities and track applications"
@@ -171,12 +176,12 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
         {/* Search and Filters */}
         <div className="flex flex-col md:flex-row gap-4 mb-6">
           <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--oklch-text-muted)]" />
             <Input
               placeholder="Search opportunities by title, description, or location..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10 bg-gray-800 border-gray-600 text-white placeholder-gray-400"
+              className="pl-10"
             />
           </div>
         </div>
@@ -184,7 +189,7 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
         {/* Tabs */}
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
           <MobileTabRail>
-            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-xl border border-gray-800 bg-gray-900 p-1">
+            <TabsList className="tabs-list-surface inline-flex h-auto min-w-max gap-1 rounded-xl p-1">
               <TabsTrigger value="all" className="min-h-10 whitespace-nowrap px-3 py-2 text-xs">
                 All Opportunities ({gigs.length})
               </TabsTrigger>
@@ -199,7 +204,7 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
               </TabsTrigger>
             </TabsList>
           </MobileTabRail>
-          <TabsList className="hidden w-full grid-cols-4 md:grid">
+          <TabsList className="tabs-list-surface hidden w-full grid-cols-4 md:grid">
             <TabsTrigger value="all">All Opportunities ({gigs.length})</TabsTrigger>
             <TabsTrigger value="active">
               Active ({statusCounts.active})
@@ -221,6 +226,6 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
           </TabsContent>
         </Tabs>
       </div>
-    </div>
+    </TotlAtmosphereShell>
   );
 }

--- a/app/client/gigs/components/gigs-results-content.tsx
+++ b/app/client/gigs/components/gigs-results-content.tsx
@@ -23,11 +23,11 @@ export default function GigsResultsContent({
 }: GigsResultsContentProps) {
   if (filteredGigs.length === 0) {
     return (
-      <Card className="border-gray-700 bg-gray-900">
+      <Card>
         <CardContent className="p-12 text-center">
-          <Building className="mx-auto mb-4 h-12 w-12 text-gray-400" />
-          <h3 className="mb-2 text-lg font-medium text-white">No opportunities found</h3>
-          <p className="mb-6 text-gray-300">
+          <Building className="mx-auto mb-4 h-12 w-12 text-[var(--oklch-text-muted)]" />
+          <h3 className="mb-2 text-lg font-medium">No opportunities found</h3>
+          <p className="mb-6 text-[var(--oklch-text-secondary)]">
             {searchTerm ? "Try adjusting your search or filters" : "Get started by posting your first opportunity"}
           </p>
           {!searchTerm && (
@@ -46,7 +46,7 @@ export default function GigsResultsContent({
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
       {filteredGigs.map((gig) => (
-        <Card key={gig.id} className="border-gray-700 bg-gray-900 transition-shadow hover:shadow-lg">
+        <Card key={gig.id} className="transition-shadow hover:shadow-lg">
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between">
               <div className="flex-1">
@@ -71,7 +71,7 @@ export default function GigsResultsContent({
               fallbackSrc="/images/totl-logo-transparent.png"
             />
 
-            <p className="line-clamp-2 text-sm text-gray-300">{gig.description}</p>
+            <p className="line-clamp-2 text-sm text-[var(--oklch-text-secondary)]">{gig.description}</p>
 
             <div className="flex items-center justify-between">
               <Badge variant="outline" className={getCategoryColor(gig.category || "")}>
@@ -82,21 +82,21 @@ export default function GigsResultsContent({
 
             <div className="space-y-2">
               <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-300">Pay Rate:</span>
-                <span className="font-medium text-white">{gig.compensation}</span>
+                <span className="text-[var(--oklch-text-secondary)]">Pay Rate:</span>
+                <span className="font-medium text-[var(--oklch-text-primary)]">{gig.compensation}</span>
               </div>
               <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-300">Applications:</span>
-                <span className="font-medium text-white">{gig.applications_count || 0}</span>
+                <span className="text-[var(--oklch-text-secondary)]">Applications:</span>
+                <span className="font-medium text-[var(--oklch-text-primary)]">{gig.applications_count || 0}</span>
               </div>
               <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-300">Posted:</span>
-                <span className="font-medium text-white">{gig.created_at}</span>
+                <span className="text-[var(--oklch-text-secondary)]">Posted:</span>
+                <span className="font-medium text-[var(--oklch-text-primary)]">{gig.created_at}</span>
               </div>
               {gig.application_deadline && (
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-300">Deadline:</span>
-                  <span className="font-medium text-white">{gig.application_deadline}</span>
+                  <span className="text-[var(--oklch-text-secondary)]">Deadline:</span>
+                  <span className="font-medium text-[var(--oklch-text-primary)]">{gig.application_deadline}</span>
                 </div>
               )}
             </div>

--- a/app/client/gigs/components/gigs-stats-overview.tsx
+++ b/app/client/gigs/components/gigs-stats-overview.tsx
@@ -21,10 +21,10 @@ export default function GigsStatsOverview({
     <>
       <div className="mb-4 md:hidden">
         <details>
-          <summary className="cursor-pointer list-none text-sm font-medium text-gray-300">
+          <summary className="cursor-pointer list-none text-sm font-medium text-[var(--oklch-text-secondary)]">
             <span className="inline-flex items-center gap-2">
               Show stats
-              <span className="text-xs text-gray-500">({totalGigs} total)</span>
+              <span className="text-xs text-[var(--oklch-text-muted)]">({totalGigs} total)</span>
             </span>
           </summary>
           <div className="mt-2">
@@ -41,12 +41,12 @@ export default function GigsStatsOverview({
       </div>
 
       <div className="mb-8 hidden gap-4 md:grid md:grid-cols-2 lg:grid-cols-4">
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Total Opportunities</p>
-                <p className="text-2xl font-bold text-white">{totalGigs}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Total Opportunities</p>
+                <p className="text-2xl font-bold">{totalGigs}</p>
               </div>
               <div className="rounded-full bg-blue-500/20 p-2">
                 <Building className="h-4 w-4 text-blue-300" />
@@ -55,12 +55,12 @@ export default function GigsStatsOverview({
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Active</p>
-                <p className="text-2xl font-bold text-white">{activeCount}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Active</p>
+                <p className="text-2xl font-bold">{activeCount}</p>
               </div>
               <div className="rounded-full bg-green-500/20 p-2">
                 <CheckCircle className="h-4 w-4 text-green-300" />
@@ -69,12 +69,12 @@ export default function GigsStatsOverview({
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Total Applications</p>
-                <p className="text-2xl font-bold text-white">{totalApplications}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Total Applications</p>
+                <p className="text-2xl font-bold">{totalApplications}</p>
               </div>
               <div className="rounded-full bg-purple-500/20 p-2">
                 <Users className="h-4 w-4 text-purple-300" />
@@ -83,12 +83,12 @@ export default function GigsStatsOverview({
           </CardContent>
         </Card>
 
-        <Card className="min-w-0 border-gray-700 bg-gray-900">
+        <Card className="min-w-0">
           <CardContent className="p-4">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-gray-300">Completed</p>
-                <p className="text-2xl font-bold text-white">{completedCount}</p>
+                <p className="text-sm font-medium text-[var(--oklch-text-secondary)]">Completed</p>
+                <p className="text-2xl font-bold">{completedCount}</p>
               </div>
               <div className="rounded-full bg-emerald-500/20 p-2">
                 <CheckCircle className="h-4 w-4 text-emerald-300" />

--- a/app/client/profile/page.tsx
+++ b/app/client/profile/page.tsx
@@ -78,8 +78,8 @@ export default async function ClientProfilePage({
             title="Client Profile (Admin View)"
             subtitle="This user does not have a client profile yet."
           />
-          <div className="p-6 bg-gray-900 rounded-lg border border-gray-700">
-            <p className="text-gray-400 text-sm">
+          <div className="rounded-lg border border-border/40 bg-card/25 p-6 backdrop-blur-sm">
+            <p className="text-sm text-[var(--oklch-text-tertiary)]">
               The client profile has not been created for this user. They may need to complete their profile setup.
             </p>
           </div>

--- a/app/client/signup/page.tsx
+++ b/app/client/signup/page.tsx
@@ -72,7 +72,7 @@ export default function ClientSignup() {
           <Info className="h-8 w-8 text-amber-400" />
         </div>
         <CardTitle className="text-center text-white">Career Builder Signup Requires Approval</CardTitle>
-        <CardDescription className="text-center text-gray-300">
+        <CardDescription className="text-center text-[var(--oklch-text-secondary)]">
           To become a Career Builder, you must apply through our approval process.
         </CardDescription>
       </CardHeader>
@@ -84,7 +84,7 @@ export default function ClientSignup() {
           </AlertDescription>
         </Alert>
 
-        <div className="space-y-3 text-sm text-gray-300">
+        <div className="space-y-3 text-sm text-[var(--oklch-text-secondary)]">
           <p className="font-semibold text-white">Here&apos;s how it works:</p>
           <ol className="ml-2 list-inside list-decimal space-y-2">
             <li>Create a Talent account (if you haven&apos;t already)</li>
@@ -113,7 +113,7 @@ export default function ClientSignup() {
           </Alert>
         )}
 
-        <p className="text-center text-sm text-gray-400">
+        <p className="text-center text-sm text-[var(--oklch-text-tertiary)]">
           {user && (userRole === "client" || profile?.role === "client")
             ? "Redirecting you to your Career Builder dashboard..."
             : "Redirecting you to the Career Builder application page..."}

--- a/app/gigs/[id]/page.tsx
+++ b/app/gigs/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { GigReferenceLinksSection } from "@/components/gigs/gig-reference-links-section";
+import { PageShell } from "@/components/layout/page-shell";
 import { FlagGigDialog } from "@/components/moderation/flag-gig-dialog";
 import { SubscriptionPrompt } from "@/components/subscription-prompt";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -10,7 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { SafeImage } from "@/components/ui/safe-image";
-import { getCategoryLabel } from "@/lib/constants/gig-categories";
+import { getCategoryBadgeVariant, getCategoryLabel } from "@/lib/constants/gig-categories";
 import { GIG_PUBLIC_WITH_CLIENT_PROFILE_SELECT, PROFILE_GIG_VIEWER_SELECT } from "@/lib/db/selects";
 import { canSeeClientDetails, getGigDisplayDescription, getGigDisplayTitle } from "@/lib/gig-access";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
@@ -85,15 +86,12 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
       ? profile
       : null;
 
-  // Note: Category color logic can be enhanced with getCategoryBadgeVariant if needed
-  // For now, keeping a simple fallback since badge styling may vary
-  const getCategoryColor = () => {
-    // Default fallback - can be enhanced with getCategoryBadgeVariant
-    return "bg-gray-100 text-gray-800";
-  };
+  const routeRole =
+    profile?.role === "talent" ? "talent" : profile?.role === "client" ? "client" : undefined;
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl">
+    <PageShell ambientTone="lifted" routeRole={routeRole} containerClassName="py-8 sm:py-10">
+      <div className="mx-auto max-w-4xl">
       {/* Back Button */}
       <div className="mb-6">
         <Button variant="ghost" asChild>
@@ -115,7 +113,7 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
                   <CardTitle className="text-3xl font-bold">{displayTitle}</CardTitle>
                   <CardDescription className="text-lg mt-2">{displayDescription}</CardDescription>
                 </div>
-                <Badge className={getCategoryColor()}>
+                <Badge variant={getCategoryBadgeVariant(gig.category || "")}>
                   {getCategoryLabel(gig.category || "")}
                 </Badge>
               </div>
@@ -147,36 +145,38 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="flex items-center gap-3">
-                  <MapPin className="h-5 w-5 text-gray-500" />
+                  <MapPin className="h-5 w-5 shrink-0 text-[var(--oklch-accent)]" />
                   <div>
                     <p className="font-medium">Location</p>
-                    <p className="text-gray-600">{gig.location}</p>
+                    <p className="text-[var(--oklch-text-tertiary)]">{gig.location}</p>
                   </div>
                 </div>
 
                 <div className="flex items-center gap-3">
-                  <DollarSign className="h-5 w-5 text-gray-500" />
+                  <DollarSign className="h-5 w-5 shrink-0 text-[var(--oklch-accent)]" />
                   <div>
                     <p className="font-medium">Compensation</p>
-                    <p className="text-gray-600">${gig.compensation}</p>
+                    <p className="text-[var(--oklch-text-tertiary)]">${gig.compensation}</p>
                   </div>
                 </div>
 
                 <div className="flex items-center gap-3">
-                  <Calendar className="h-5 w-5 text-gray-500" />
+                  <Calendar className="h-5 w-5 shrink-0 text-[var(--oklch-accent)]" />
                   <div>
                     <p className="font-medium">Date</p>
-                    <p className="text-gray-600">
+                    <p className="text-[var(--oklch-text-tertiary)]">
                       {gig.date ? new Date(gig.date).toLocaleDateString() : "TBD"}
                     </p>
                   </div>
                 </div>
 
                 <div className="flex items-center gap-3">
-                  <Clock className="h-5 w-5 text-gray-500" />
+                  <Clock className="h-5 w-5 shrink-0 text-[var(--oklch-accent)]" />
                   <div>
                     <p className="font-medium">Posted</p>
-                    <p className="text-gray-600">{new Date(gig.created_at).toLocaleDateString()}</p>
+                    <p className="text-[var(--oklch-text-tertiary)]">
+                      {new Date(gig.created_at).toLocaleDateString()}
+                    </p>
                   </div>
                 </div>
               </div>
@@ -199,12 +199,12 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
                   <div className="space-y-3">
                     <div>
                       <p className="font-medium">Company</p>
-                      <p className="text-gray-600">{gig.profiles.display_name}</p>
+                      <p className="text-[var(--oklch-text-tertiary)]">{gig.profiles.display_name}</p>
                     </div>
                     {gig.profiles.role && (
                       <div>
                         <p className="font-medium">Role</p>
-                        <p className="text-gray-600">{gig.profiles.role}</p>
+                        <p className="text-[var(--oklch-text-tertiary)]">{gig.profiles.role}</p>
                       </div>
                     )}
                   </div>
@@ -236,7 +236,9 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
               </CardHeader>
               <CardContent>
                 <div className="text-center py-8">
-                  <p className="text-gray-500 mb-4">Client details are only visible to registered users</p>
+                  <p className="text-[var(--oklch-text-muted)] mb-4">
+                    Client details are only visible to registered users
+                  </p>
                   <Button asChild className="apple-button">
                     <Link href="/login">Sign In to View Client Info</Link>
                   </Button>
@@ -258,23 +260,23 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
             <CardContent className="space-y-4">
               {!user ? (
                 <div className="space-y-3">
-                  <p className="text-sm text-gray-600">
-                    Sign in to apply for this opportunity.
-                  </p>
-                  <Link
-                    data-testid="gig-signin-link"
-                    href={`/login?returnUrl=${encodeURIComponent(`/gigs/${gig.id}`)}`}
-                    className="inline-flex w-full items-center justify-center rounded-lg border border-slate-300 bg-white py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-50"
+                  <p className="text-sm text-[var(--oklch-text-tertiary)]">Sign in to apply for this opportunity.</p>
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="w-full border-[var(--oklch-accent)]/40 bg-card/30 text-[var(--oklch-text-primary)] hover:bg-card/45"
                   >
-                    Sign in to apply
-                  </Link>
+                    <Link data-testid="gig-signin-link" href={`/login?returnUrl=${encodeURIComponent(`/gigs/${gig.id}`)}`}>
+                      Sign in to apply
+                    </Link>
+                  </Button>
                 </div>
               ) : hasApplied ? (
                 <div className="text-center space-y-3">
                   <Badge variant="secondary" className="w-full">
                     Application Submitted
                   </Badge>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-[var(--oklch-text-tertiary)]">
                     You&apos;ve already applied for this opportunity. Check your dashboard for updates.
                   </p>
                   <Button asChild variant="outline" className="w-full">
@@ -282,13 +284,13 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
                   </Button>
                 </div>
               ) : profile?.role !== "talent" ? (
-                <div className="space-y-3 text-sm text-gray-600">
+                <div className="space-y-3 text-sm text-[var(--oklch-text-tertiary)]">
                   Only talent accounts can submit applications.
                 </div>
               ) : !canApply ? (
                 <div className="space-y-4" data-testid="subscription-apply-gate">
-                  <Alert className="bg-amber-500/10 border-amber-500/30">
-                    <AlertDescription className="text-amber-100 text-sm">
+                  <Alert className="border-amber-400/35 bg-amber-500/10">
+                    <AlertDescription className="text-[var(--oklch-text-secondary)] text-sm">
                       You need an active subscription to apply to this opportunity and see full client
                       details.
                     </AlertDescription>
@@ -302,7 +304,7 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
                 </div>
               ) : (
                 <div className="space-y-3">
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-[var(--oklch-text-tertiary)]">
                     Ready to apply? Click below to submit your application.
                   </p>
                   <Button asChild className="w-full button-glow border-0">
@@ -323,15 +325,15 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
             </CardHeader>
             <CardContent className="space-y-3">
               <div className="flex justify-between">
-                <span className="text-gray-600">Opportunity Type</span>
+                <span className="text-[var(--oklch-text-tertiary)]">Opportunity Type</span>
                 <span className="font-medium">{getCategoryLabel(gig.category || "")}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Compensation</span>
+                <span className="text-[var(--oklch-text-tertiary)]">Compensation</span>
                 <span className="font-medium">${gig.compensation}</span>
               </div>
               <div className="flex justify-between">
-                <span className="text-gray-600">Location</span>
+                <span className="text-[var(--oklch-text-tertiary)]">Location</span>
                 <span className="font-medium">{gig.location}</span>
               </div>
             </CardContent>
@@ -356,6 +358,7 @@ export default async function GigDetailsPage({ params }: GigDetailsPageProps) {
           </Card>
         </div>
       </div>
-    </div>
+      </div>
+    </PageShell>
   );
 }

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -8,6 +8,7 @@ import { GigCard } from "@/components/gigs/gig-card";
 import { GigsFilterForm } from "@/components/gigs/gigs-filter-form";
 import { RetryButton } from "@/components/gigs/retry-button";
 import { SavedSearchesBar } from "@/components/gigs/saved-searches-bar";
+import { PageShell } from "@/components/layout/page-shell";
 import { SubscriptionPrompt } from "@/components/subscription-prompt";
 import { Button } from "@/components/ui/button";
 import { getCategoryFilterSet } from "@/lib/constants/gig-categories";
@@ -258,39 +259,37 @@ export default async function GigsPage({
   if (error && error.code !== "PGRST103") {
     logger.error("Error fetching gigs", error);
     return (
-      <div className="min-h-screen bg-black pt-40">
-        <div className="container mx-auto px-4 py-16">
-          <div className="max-w-6xl mx-auto">
-            <div className="mb-16 text-center">
-              <h1 className="text-6xl lg:text-7xl font-bold mb-8 text-white animate-apple-fade-in">
-                Find Opportunities
-              </h1>
-              <p className="text-xl text-gray-300 max-w-4xl mx-auto leading-relaxed animate-apple-slide-up">
-                Browse through available opportunities. Filter by opportunity type,
-                location, and more to find the perfect match for your talents.
-              </p>
-            </div>
-            <div className="text-center py-20">
-              <div className="max-w-2xl mx-auto">
-                <div className="mb-8 animate-apple-scale-in">
-                  <div className="w-24 h-24 mx-auto bg-red-500/10 rounded-full flex items-center justify-center mb-6">
-                    <Search className="h-12 w-12 text-red-400" />
-                  </div>
+      <PageShell ambientTone="lifted" containerClassName="py-16 sm:py-20">
+        <div className="max-w-6xl mx-auto">
+          <div className="mb-16 text-center">
+            <h1 className="text-6xl lg:text-7xl font-bold mb-8 text-[var(--oklch-text-primary)] animate-apple-fade-in">
+              Find Opportunities
+            </h1>
+            <p className="text-xl text-[var(--oklch-text-secondary)] max-w-4xl mx-auto leading-relaxed animate-apple-slide-up">
+              Browse through available opportunities. Filter by opportunity type, location, and more to find the
+              perfect match for your talents.
+            </p>
+          </div>
+          <div className="text-center py-20">
+            <div className="max-w-2xl mx-auto">
+              <div className="mb-8 animate-apple-scale-in">
+                <div className="w-24 h-24 mx-auto bg-red-500/10 rounded-full flex items-center justify-center mb-6">
+                  <Search className="h-12 w-12 text-red-400" />
                 </div>
-                <h3 className="text-3xl font-bold text-white mb-4 animate-apple-fade-in">
-                  Unable to Load Opportunities
-                </h3>
-                <p className="text-xl text-gray-300 mb-8 leading-relaxed animate-apple-slide-up">
-                  We&apos;re experiencing technical difficulties. Please try again later.
-                </p>
-                <RetryButton className="apple-button px-8 py-4 text-lg animate-apple-glow">
-                  Try Again
-                </RetryButton>
               </div>
+              <h3 className="text-3xl font-bold text-[var(--oklch-text-primary)] mb-4 animate-apple-fade-in">
+                Unable to Load Opportunities
+              </h3>
+              <p className="text-xl text-[var(--oklch-text-secondary)] mb-8 leading-relaxed animate-apple-slide-up">
+                We&apos;re experiencing technical difficulties. Please try again later.
+              </p>
+              <RetryButton className="apple-button px-8 py-4 text-lg animate-apple-glow">
+                Try Again
+              </RetryButton>
             </div>
           </div>
         </div>
-      </div>
+      </PageShell>
     );
   }
 
@@ -324,9 +323,12 @@ export default async function GigsPage({
   }
 
   return (
-    <div className="min-h-screen bg-[var(--oklch-bg)] pt-28 sm:pt-32">
-      <div className="container mx-auto px-4 py-10 sm:py-14 md:py-16">
-        <div className="max-w-6xl mx-auto">
+    <PageShell
+      ambientTone="lifted"
+      routeRole={userRole === "talent" ? "talent" : userRole === "client" ? "client" : undefined}
+      containerClassName="py-10 sm:py-14 md:py-16"
+    >
+      <div className="max-w-6xl mx-auto">
           {/* Breadcrumb / Back */}
           <div className="mb-5 sm:mb-8 px-2 sm:px-0">
             <div className="sm:hidden">
@@ -456,7 +458,7 @@ export default async function GigsPage({
                   <h3 className="text-3xl font-bold text-white mb-4 animate-apple-fade-in">
                     No Active Opportunities
                   </h3>
-                  <p className="text-xl text-gray-300 mb-8 leading-relaxed animate-apple-slide-up">
+                  <p className="mb-8 text-xl leading-relaxed text-[var(--oklch-text-secondary)] animate-apple-slide-up">
                     There are currently no active opportunities available. Check back later for new
                     opportunities!
                   </p>
@@ -511,7 +513,6 @@ export default async function GigsPage({
             </div>
           </div>
         </div>
-      </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/settings/loading.tsx
+++ b/app/settings/loading.tsx
@@ -1,51 +1,48 @@
+import { PageShell } from "@/components/layout/page-shell";
+
 export default function SettingsLoading() {
   return (
-    <div className="min-h-screen bg-black page-ambient text-white">
-      <div className="container mx-auto px-4 py-8">
-        <div className="max-w-4xl mx-auto">
-          <div className="mb-8">
-            <div className="h-8 bg-white/10 rounded w-48 mb-2 animate-pulse" />
-            <div className="h-4 bg-white/10 rounded w-96 animate-pulse" />
+    <PageShell className="grain-texture" containerClassName="py-8">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-8">
+          <div className="mb-2 h-8 w-48 animate-pulse rounded-lg bg-muted/40" />
+          <div className="h-4 w-96 max-w-full animate-pulse rounded-lg bg-muted/35" />
+        </div>
+
+        <div className="space-y-6">
+          <div className="panel-frosted rounded-2xl p-6">
+            <div className="mb-4 h-6 w-40 animate-pulse rounded-lg bg-muted/40" />
+            <div className="mb-6 h-4 w-64 max-w-full animate-pulse rounded-lg bg-muted/35" />
+            <div className="space-y-4">
+              <div>
+                <div className="mb-2 h-4 w-16 animate-pulse rounded bg-muted/35" />
+                <div className="h-10 animate-pulse rounded-xl bg-muted/30" />
+              </div>
+              <div>
+                <div className="mb-2 h-4 w-24 animate-pulse rounded bg-muted/35" />
+                <div className="h-10 animate-pulse rounded-xl bg-muted/30" />
+              </div>
+            </div>
           </div>
 
-          <div className="space-y-6">
-            {/* Account Information Card */}
-            <div className="panel-frosted rounded-lg p-6">
-              <div className="h-6 bg-white/10 rounded w-40 mb-4 animate-pulse" />
-              <div className="h-4 bg-white/10 rounded w-64 mb-6 animate-pulse" />
-              <div className="space-y-4">
-                <div>
-                  <div className="h-4 bg-white/10 rounded w-16 mb-2 animate-pulse" />
-                  <div className="h-10 bg-white/10 rounded animate-pulse" />
+          <div className="panel-frosted rounded-2xl p-6">
+            <div className="mb-4 h-6 w-32 animate-pulse rounded-lg bg-muted/40" />
+            <div className="mb-6 h-4 w-80 max-w-full animate-pulse rounded-lg bg-muted/35" />
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {[...Array(6)].map((_, i) => (
+                <div key={i}>
+                  <div className="mb-2 h-4 w-20 animate-pulse rounded bg-muted/35" />
+                  <div className="h-10 animate-pulse rounded-xl bg-muted/30" />
                 </div>
-                <div>
-                  <div className="h-4 bg-white/10 rounded w-24 mb-2 animate-pulse" />
-                  <div className="h-10 bg-white/10 rounded animate-pulse" />
-                </div>
-              </div>
+              ))}
             </div>
+          </div>
 
-            {/* Role-Specific Card */}
-            <div className="panel-frosted rounded-lg p-6">
-              <div className="h-6 bg-white/10 rounded w-32 mb-4 animate-pulse" />
-              <div className="h-4 bg-white/10 rounded w-80 mb-6 animate-pulse" />
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {[...Array(6)].map((_, i) => (
-                  <div key={i}>
-                    <div className="h-4 bg-white/10 rounded w-20 mb-2 animate-pulse" />
-                    <div className="h-10 bg-white/10 rounded animate-pulse" />
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            {/* Submit Button */}
-            <div className="flex justify-end">
-              <div className="h-10 bg-white/10 rounded w-32 animate-pulse" />
-            </div>
+          <div className="flex justify-end">
+            <div className="h-10 w-32 animate-pulse rounded-xl bg-muted/35" />
           </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/settings/sections/client-details.tsx
+++ b/app/settings/sections/client-details.tsx
@@ -138,7 +138,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
     <Card className="bg-gray-800 border-gray-700">
       <CardHeader>
         <CardTitle className="text-white">Client Details</CardTitle>
-        <CardDescription className="text-gray-400">
+        <CardDescription className="text-[var(--oklch-text-tertiary)]">
           Update your company and contact information
         </CardDescription>
       </CardHeader>
@@ -151,7 +151,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
             <div className="space-y-2">
               <Label
                 htmlFor="company_name"
-                className={errors.company_name ? "text-red-400" : "text-gray-300"}
+                className={errors.company_name ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
               >
                 Company Name *
               </Label>
@@ -173,7 +173,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="industry" className="text-gray-300">
+                <Label htmlFor="industry" className="text-[var(--oklch-text-secondary)]">
                   Industry
                 </Label>
                 <Select
@@ -199,7 +199,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="company_size" className="text-gray-300">
+                <Label htmlFor="company_size" className="text-[var(--oklch-text-secondary)]">
                   Company Size
                 </Label>
                 <Select
@@ -224,7 +224,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
             <div className="space-y-2">
               <Label
                 htmlFor="website"
-                className={errors.website ? "text-red-400" : "text-gray-300"}
+                className={errors.website ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
               >
                 Company Website
               </Label>
@@ -251,7 +251,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
             <div className="space-y-2">
               <Label
                 htmlFor="contact_name"
-                className={errors.contact_name ? "text-red-400" : "text-gray-300"}
+                className={errors.contact_name ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
               >
                 Contact Person Name *
               </Label>
@@ -275,7 +275,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
               <div className="space-y-2">
                 <Label
                   htmlFor="contact_email"
-                  className={errors.contact_email ? "text-red-400" : "text-gray-300"}
+                  className={errors.contact_email ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
                 >
                   Contact Email *
                 </Label>
@@ -297,7 +297,7 @@ export function ClientDetailsSection({ client }: ClientDetailsSectionProps) {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="contact_phone" className="text-gray-300">
+                <Label htmlFor="contact_phone" className="text-[var(--oklch-text-secondary)]">
                   Contact Phone
                 </Label>
                 <Input

--- a/app/talent/dashboard/client.tsx
+++ b/app/talent/dashboard/client.tsx
@@ -784,7 +784,11 @@ function TalentDashboardContent({
   // No fatalError check needed - component won't render if client creation fails
   if (authLoading || dataLoading || isInVerificationGracePeriodRef.current) {
     return (
-      <PageShell className="grain-texture glow-backplate text-white" containerClassName="flex min-h-[70vh] items-center justify-center py-8">
+      <PageShell
+        ambientTone="lifted"
+        className="grain-texture glow-backplate text-[var(--oklch-text-primary)]"
+        containerClassName="flex min-h-[70vh] items-center justify-center py-8"
+      >
         <div className="text-center">
           <div className="mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-white/70" />
           <p className="mt-4 text-[var(--oklch-text-secondary)]">Loading your dashboard...</p>
@@ -810,7 +814,11 @@ function TalentDashboardContent({
 
   if (user && !profile) {
     return (
-      <PageShell className="grain-texture glow-backplate text-white" containerClassName="flex min-h-[70vh] items-center justify-center py-8">
+      <PageShell
+        ambientTone="lifted"
+        className="grain-texture glow-backplate text-[var(--oklch-text-primary)]"
+        containerClassName="flex min-h-[70vh] items-center justify-center py-8"
+      >
         <SectionCard className="mx-auto w-full max-w-md text-center">
           <AlertCircle className="mx-auto mb-4 h-12 w-12 text-amber-400" aria-hidden />
           <h2 className="mb-2 text-xl font-semibold text-[var(--oklch-text-primary)]">Finishing your setup</h2>
@@ -827,7 +835,11 @@ function TalentDashboardContent({
 
   if (!user) {
     return (
-      <PageShell className="grain-texture glow-backplate text-white" containerClassName="flex min-h-[70vh] items-center justify-center py-8">
+      <PageShell
+        ambientTone="lifted"
+        className="grain-texture glow-backplate text-[var(--oklch-text-primary)]"
+        containerClassName="flex min-h-[70vh] items-center justify-center py-8"
+      >
         <SectionCard className="mx-auto w-full max-w-md text-center">
           <User className="mx-auto mb-6 h-16 w-16 text-[var(--oklch-text-secondary)]" aria-hidden />
           <h2 className="mb-3 text-2xl font-bold text-[var(--oklch-text-primary)]">Welcome back</h2>
@@ -853,7 +865,7 @@ function TalentDashboardContent({
   }
 
   return (
-    <PageShell topPadding={false} fullBleed>
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
       <div className="panel-frosted sticky top-0 z-40 border-b border-border/40">
         <div className="container mx-auto px-4 py-2 sm:py-3">
           <div className="flex min-h-12 items-center justify-between gap-2 md:hidden">
@@ -870,7 +882,7 @@ function TalentDashboardContent({
               </Avatar>
               <div className="min-w-0">
                 <p className="truncate text-base font-semibold text-white">Talent Dashboard</p>
-                <p className="truncate text-xs text-gray-300">
+                <p className="truncate text-xs text-[var(--oklch-text-secondary)]">
                   {talentProfile?.first_name ? `Welcome back, ${talentProfile.first_name}` : "Ready to discover opportunities"}
                 </p>
               </div>
@@ -904,7 +916,7 @@ function TalentDashboardContent({
                 <h1 className="text-2xl font-bold text-white">
                   Welcome back, {talentProfile?.first_name || "Talent"}!
                 </h1>
-                <p className="text-gray-300">Ready to discover your next opportunity?</p>
+                <p className="text-[var(--oklch-text-secondary)]">Ready to discover your next opportunity?</p>
               </div>
             </div>
             <div className="flex items-center gap-2">
@@ -912,7 +924,7 @@ function TalentDashboardContent({
                 viewAllHref="/talent/dashboard"
                 variant="outline"
                 size="sm"
-                className="border-gray-700 text-white hover:bg-gray-800"
+                className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10"
                 showLabel
               />
               <Button size="sm" className="bg-white text-black hover:bg-gray-200" asChild>
@@ -925,7 +937,7 @@ function TalentDashboardContent({
                 variant="outline"
                 size="sm"
                 asChild
-                className="border-gray-700 text-white hover:bg-gray-800"
+                className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10"
               >
                 <Link href="/settings" className="flex items-center">
                   <Settings className="h-4 w-4 mr-2" />
@@ -937,7 +949,7 @@ function TalentDashboardContent({
                 size="sm"
                 onClick={handleSignOut}
                 disabled={isSigningOut}
-                className="border-gray-700 text-white hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <LogOut className="h-4 w-4 mr-2" />
                 {isSigningOut ? "Signing Out..." : "Sign Out"}
@@ -980,7 +992,7 @@ function TalentDashboardContent({
         </div>
 
         <div className="mb-8 hidden gap-4 md:grid md:grid-cols-2 lg:grid-cols-3">
-          <Card className="flex h-full min-w-0 flex-col bg-gray-900 border-gray-800 transition-shadow hover:shadow-md">
+          <Card className="flex h-full min-w-0 flex-col transition-shadow hover:shadow-md">
             <CardContent className="flex flex-1 flex-col p-4">
               <div className="flex-1 space-y-3">
                 <div className="card-header-row">
@@ -998,7 +1010,7 @@ function TalentDashboardContent({
             </CardContent>
           </Card>
 
-          <Card className="flex h-full min-w-0 flex-col bg-gray-900 border-gray-800 transition-shadow hover:shadow-md">
+          <Card className="flex h-full min-w-0 flex-col transition-shadow hover:shadow-md">
             <CardContent className="flex flex-1 flex-col p-4">
               <div className="flex-1 space-y-3">
                 <div className="card-header-row">
@@ -1016,7 +1028,7 @@ function TalentDashboardContent({
             </CardContent>
           </Card>
 
-          <Card className="flex h-full min-w-0 flex-col bg-gray-900 border-gray-800 transition-shadow hover:shadow-md">
+          <Card className="flex h-full min-w-0 flex-col transition-shadow hover:shadow-md">
             <CardContent className="flex flex-1 flex-col p-4">
               <div className="flex-1 space-y-3">
                 <div className="card-header-row">
@@ -1037,62 +1049,62 @@ function TalentDashboardContent({
 
         <Tabs defaultValue="overview" className="space-y-6">
           <MobileTabRail>
-            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-xl border border-gray-800 bg-gray-900 p-1">
+            <TabsList className="inline-flex h-auto min-w-max gap-1 rounded-xl p-1">
               <TabsTrigger
                 value="overview"
-                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs text-white data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs"
               >
                 <Activity className="h-3.5 w-3.5" />
                 Overview
               </TabsTrigger>
               <TabsTrigger
                 value="applications"
-                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs"
               >
                 <Target className="h-3.5 w-3.5" />
                 Applications
               </TabsTrigger>
               <TabsTrigger
                 value="bookings"
-                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs"
               >
                 <Calendar className="h-3.5 w-3.5" />
                 Bookings
               </TabsTrigger>
               <TabsTrigger
                 value="discover"
-                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+                className="min-h-10 whitespace-nowrap px-3 py-2 text-xs"
               >
                 <Search className="h-3.5 w-3.5" />
                 Discover
               </TabsTrigger>
             </TabsList>
           </MobileTabRail>
-          <TabsList className="hidden w-full grid-cols-4 border-gray-800 bg-gray-900 md:grid lg:w-auto lg:grid-cols-4">
+          <TabsList className="hidden w-full grid-cols-4 md:grid lg:w-auto lg:grid-cols-4">
             <TabsTrigger
               value="overview"
-              className="flex items-center gap-2 text-white data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+              className="flex min-h-10 items-center gap-2 px-3 py-2"
             >
               <Activity className="h-4 w-4" />
               Overview
             </TabsTrigger>
             <TabsTrigger
               value="applications"
-              className="flex items-center gap-2 text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+              className="flex min-h-10 items-center gap-2 px-3 py-2"
             >
               <Target className="h-4 w-4" />
               Applications
             </TabsTrigger>
             <TabsTrigger
               value="bookings"
-              className="flex items-center gap-2 text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+              className="flex min-h-10 items-center gap-2 px-3 py-2"
             >
               <Calendar className="h-4 w-4" />
               Bookings
             </TabsTrigger>
             <TabsTrigger
               value="discover"
-              className="flex items-center gap-2 text-gray-300 data-[state=active]:bg-gray-800 data-[state=active]:text-white"
+              className="flex min-h-10 items-center gap-2 px-3 py-2"
             >
               <Search className="h-4 w-4" />
               Discover
@@ -1102,7 +1114,7 @@ function TalentDashboardContent({
           <TabsContent value="overview" className="space-y-6">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
               {/* Primary CTA: Browse Opportunities first */}
-              <Card className="lg:col-span-1 bg-gray-900 border-gray-800">
+              <Card className="lg:col-span-1">
                 <CardHeader>
                   <div className="card-header-row">
                     <CardTitle className="flex items-center gap-2 text-white">
@@ -1113,7 +1125,7 @@ function TalentDashboardContent({
                       Live
                     </Badge>
                   </div>
-                  <CardDescription className="text-gray-300">
+                  <CardDescription className="text-[var(--oklch-text-secondary)]">
                     Discover new opportunities
                   </CardDescription>
                 </CardHeader>
@@ -1131,7 +1143,7 @@ function TalentDashboardContent({
                 </CardContent>
               </Card>
 
-              <Card className="lg:col-span-1 bg-gray-900 border-gray-800">
+              <Card className="lg:col-span-1">
                 <CardHeader>
                   <div className="card-header-row">
                     <CardTitle className="flex items-center gap-2 text-white">
@@ -1142,7 +1154,7 @@ function TalentDashboardContent({
                       Snapshot
                     </Badge>
                   </div>
-                  <CardDescription className="text-gray-300">Your activity summary</CardDescription>
+                  <CardDescription className="text-[var(--oklch-text-secondary)]">Your activity summary</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid grid-cols-2 gap-4">
@@ -1163,7 +1175,7 @@ function TalentDashboardContent({
               </Card>
             </div>
 
-            <Card className="lg:col-span-2 bg-gray-900 border-gray-800">
+            <Card className="lg:col-span-2">
               <CardHeader>
                 <div className="card-header-row">
                   <CardTitle className="flex items-center gap-2 text-white">
@@ -1174,7 +1186,7 @@ function TalentDashboardContent({
                     Confirmed
                   </Badge>
                 </div>
-                <CardDescription className="text-gray-300">
+                <CardDescription className="text-[var(--oklch-text-secondary)]">
                   Your confirmed and pending bookings
                 </CardDescription>
               </CardHeader>
@@ -1204,10 +1216,10 @@ function TalentDashboardContent({
                                 <p className="text-sm font-semibold text-white truncate">
                                   {app.gigs?.title}
                                 </p>
-                                <p className="text-xs text-gray-300">
+                                <p className="text-xs text-[var(--oklch-text-secondary)]">
                                   {app.gigs?.client_profiles?.company_name || "Private Client"}
                                 </p>
-                                <div className="flex items-center gap-2 text-xs text-gray-400">
+                                <div className="flex items-center gap-2 text-xs text-[var(--oklch-text-tertiary)]">
                                   <span className="flex items-center gap-1">
                                     <Calendar className="h-3 w-3" />
                                     <SafeDate date={app.created_at} />
@@ -1220,7 +1232,7 @@ function TalentDashboardContent({
                               </div>
                               <div className="flex flex-col items-end gap-2">
                                 <ApplicationStatusBadge status={app.status} showIcon={false} />
-                                <Button variant="ghost" size="icon" className="text-gray-400">
+                                <Button variant="ghost" size="icon" className="text-[var(--oklch-text-muted)]">
                                   <ChevronRight className="h-4 w-4" />
                                 </Button>
                               </div>
@@ -1240,7 +1252,7 @@ function TalentDashboardContent({
                         .map((app) => (
                           <div
                             key={app.id}
-                            className="flex flex-col md:flex-row gap-4 p-4 border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
+                            className="flex flex-col gap-4 rounded-lg border border-border/40 p-4 transition-shadow hover:shadow-md md:flex-row"
                           >
                             <div className="w-full md:w-20 h-20 relative rounded-lg overflow-hidden flex-shrink-0">
                               <SafeImage
@@ -1259,10 +1271,10 @@ function TalentDashboardContent({
                                 </h4>
                                 <ApplicationStatusBadge status={app.status} showIcon={true} />
                               </div>
-                              <p className="text-gray-300 font-medium">
+                              <p className="text-[var(--oklch-text-secondary)] font-medium">
                                 {app.gigs?.client_profiles?.company_name || "Private Client"}
                               </p>
-                              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-gray-300">
+                              <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-[var(--oklch-text-secondary)]">
                                 <div className="flex items-center gap-1">
                                   <Calendar className="h-4 w-4" />
                                   <SafeDate date={app.created_at} />
@@ -1299,8 +1311,8 @@ function TalentDashboardContent({
                   </>
                 ) : (
                   <div className="text-center py-8">
-                    <Calendar className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                    <p className="text-gray-300 mb-4">You don&apos;t have any upcoming opportunities.</p>
+                    <Calendar className="h-12 w-12 text-[var(--oklch-text-tertiary)] mx-auto mb-4" />
+                    <p className="text-[var(--oklch-text-secondary)] mb-4">You don&apos;t have any upcoming opportunities.</p>
                     <Button asChild className="bg-purple-600 hover:bg-purple-700 text-white">
                       <Link href="/gigs">Browse Available Opportunities</Link>
                     </Button>
@@ -1311,17 +1323,17 @@ function TalentDashboardContent({
           </TabsContent>
 
           <TabsContent value="applications" className="space-y-6">
-            <Card className="bg-gray-900 border-gray-800">
+            <Card>
               <CardHeader>
                 <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                   <div className="space-y-2">
                     <div className="card-header-row">
-                      <CardTitle className="text-white">My TalentApplications</CardTitle>
+                      <CardTitle>My Applications</CardTitle>
                       <Badge variant="outline" className="status-chip">
                         Active
                       </Badge>
                     </div>
-                    <CardDescription className="text-gray-300">
+                    <CardDescription className="text-[var(--oklch-text-secondary)]">
                       Track all your opportunity applications and their status
                     </CardDescription>
                   </div>
@@ -1329,7 +1341,7 @@ function TalentDashboardContent({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="border-gray-700 text-white hover:bg-gray-800"
+                      className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10"
                     >
                       <Filter className="h-4 w-4 mr-2" />
                       Filter
@@ -1337,7 +1349,7 @@ function TalentDashboardContent({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="border-gray-700 text-white hover:bg-gray-800"
+                      className="border-white/15 text-[var(--oklch-text-primary)] hover:bg-white/10"
                     >
                       Export
                     </Button>
@@ -1349,7 +1361,7 @@ function TalentDashboardContent({
                 {applicationsLoading ? (
                   <div className="text-center py-12">
                     <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
-                    <p className="mt-4 text-gray-300">Loading your applications...</p>
+                    <p className="mt-4 text-[var(--oklch-text-secondary)]">Loading your applications...</p>
                   </div>
                 ) : applicationsError ? (
                   <EmptyState
@@ -1398,10 +1410,10 @@ function TalentDashboardContent({
                               <p className="text-sm font-semibold text-white truncate">
                                 {app.gigs?.title}
                               </p>
-                              <p className="text-xs text-gray-300">
+                              <p className="text-xs text-[var(--oklch-text-secondary)]">
                                 {app.gigs?.client_profiles?.company_name || "Private Client"}
                               </p>
-                              <div className="flex items-center gap-2 text-xs text-gray-400">
+                              <div className="flex items-center gap-2 text-xs text-[var(--oklch-text-tertiary)]">
                                 <span className="flex items-center gap-1">
                                   <DollarSign className="h-3 w-3" />
                                   {app.gigs?.compensation || "TBD"}
@@ -1417,7 +1429,7 @@ function TalentDashboardContent({
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="text-gray-400 hover:bg-gray-700"
+                                className="text-[var(--oklch-text-muted)] hover:bg-white/10"
                                 onClick={() => handleViewDetails(app)}
                               >
                                 <ChevronRight className="h-4 w-4" />
@@ -1441,7 +1453,7 @@ function TalentDashboardContent({
                       {applications.map((app) => (
                         <div
                           key={app.id}
-                          className="flex flex-col md:flex-row gap-4 p-4 border border-gray-700 rounded-lg hover:shadow-md transition-shadow bg-gray-800"
+                          className="panel-frosted flex flex-col gap-4 rounded-lg border border-border/40 p-4 transition-shadow hover:shadow-md md:flex-row"
                         >
                           <div className="w-full md:w-24 h-24 relative rounded-lg overflow-hidden flex-shrink-0">
                             <SafeImage
@@ -1458,10 +1470,10 @@ function TalentDashboardContent({
                               <h4 className="font-semibold text-lg text-white">{app.gigs?.title}</h4>
                               <ApplicationStatusBadge status={app.status} showIcon={true} />
                             </div>
-                            <p className="text-gray-300 font-medium">
+                            <p className="text-[var(--oklch-text-secondary)] font-medium">
                               {app.gigs?.client_profiles?.company_name || "Private Client"}
                             </p>
-                            <div className="flex flex-wrap gap-4 text-sm text-gray-400">
+                            <div className="flex flex-wrap gap-4 text-sm text-[var(--oklch-text-tertiary)]">
                               <Badge
                                 variant="outline"
                                 className={getCategoryColor(app.gigs?.category || "General")}
@@ -1481,7 +1493,7 @@ function TalentDashboardContent({
                             <Button
                               variant="outline"
                               size="sm"
-                              className="flex-1 md:flex-none bg-transparent border-gray-700 text-white hover:bg-gray-700"
+                              className="flex-1 border-white/15 bg-transparent md:flex-none hover:bg-white/10"
                               onClick={() => handleViewDetails(app)}
                             >
                               View Details
@@ -1489,7 +1501,7 @@ function TalentDashboardContent({
                             <Button
                               variant="ghost"
                               size="sm"
-                              className="text-gray-400 hover:bg-gray-700"
+                              className="text-[var(--oklch-text-muted)] hover:bg-white/10"
                             >
                               <MoreVertical className="h-4 w-4" />
                             </Button>
@@ -1548,10 +1560,10 @@ function TalentDashboardContent({
                               <p className="text-sm font-semibold text-white truncate">
                                 {booking.gigs?.title}
                               </p>
-                              <p className="text-xs text-gray-300">
+                              <p className="text-xs text-[var(--oklch-text-secondary)]">
                                 {booking.gigs?.client_profiles?.company_name || "Private Client"}
                               </p>
-                              <div className="flex items-center gap-2 text-xs text-gray-400">
+                              <div className="flex items-center gap-2 text-xs text-[var(--oklch-text-tertiary)]">
                                 <span className="flex items-center gap-1">
                                   <Calendar className="h-3 w-3" />
                                   <SafeDate date={booking.date} format="datetime" />
@@ -1569,7 +1581,7 @@ function TalentDashboardContent({
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="text-gray-400 hover:bg-gray-700"
+                                className="text-[var(--oklch-text-muted)] hover:bg-white/10"
                                 onClick={() => handleViewBookingDetails(booking)}
                               >
                                 <ChevronRight className="h-4 w-4" />
@@ -1593,7 +1605,7 @@ function TalentDashboardContent({
                       {bookings.map((booking) => (
                         <div
                           key={booking.id}
-                          className="flex flex-col md:flex-row gap-4 p-4 border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
+                          className="flex flex-col gap-4 rounded-lg border border-border/40 p-4 transition-shadow hover:shadow-md md:flex-row"
                         >
                           <div className="w-full md:w-24 h-24 relative rounded-lg overflow-hidden flex-shrink-0">
                             <SafeImage
@@ -1612,10 +1624,10 @@ function TalentDashboardContent({
                               </h4>
                               <ApplicationStatusBadge status="accepted" showIcon={true} />
                             </div>
-                            <p className="text-gray-300 font-medium">
+                            <p className="text-[var(--oklch-text-secondary)] font-medium">
                               {booking.gigs?.client_profiles?.company_name || "Private Client"}
                             </p>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-gray-300">
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-[var(--oklch-text-secondary)]">
                               <div className="flex items-center gap-1">
                                 <Calendar className="h-4 w-4" />
                                 <SafeDate date={booking.date} format="datetime" />
@@ -1697,7 +1709,7 @@ function TalentDashboardContent({
                 {dataLoading ? (
                   <div className="text-center py-12">
                     <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600 mx-auto"></div>
-                    <p className="mt-4 text-gray-300">Loading available opportunities...</p>
+                    <p className="mt-4 text-[var(--oklch-text-secondary)]">Loading available opportunities...</p>
                   </div>
                 ) : dataError ? (
                   <EmptyState

--- a/app/talent/dashboard/loading.tsx
+++ b/app/talent/dashboard/loading.tsx
@@ -1,49 +1,33 @@
+import { PageShell } from "@/components/layout/page-shell";
+import { Skeleton } from "@/components/ui/skeleton";
+
 export default function TalentDashboardLoading() {
   return (
-    <div className="min-h-screen bg-black page-ambient">
-      {/* Header skeleton */}
-      <div className="panel-frosted sticky top-0 z-40 border-b border-border/40">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
+      <div className="px-4 py-8">
+        <div className="mx-auto w-full max-w-6xl space-y-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 bg-white/10 rounded-full animate-pulse" />
+              <Skeleton className="h-12 w-12 shrink-0 rounded-full bg-muted/40" />
               <div className="space-y-2">
-                <div className="h-6 w-48 bg-white/10 rounded animate-pulse" />
-                <div className="h-4 w-32 bg-white/10 rounded animate-pulse" />
+                <Skeleton className="h-7 w-56 rounded-lg bg-muted/40" />
+                <Skeleton className="h-4 w-72 max-w-full rounded-lg bg-muted/35" />
               </div>
             </div>
-            <div className="flex items-center gap-2">
-              <div className="h-9 w-24 bg-white/10 rounded animate-pulse" />
-              <div className="h-9 w-24 bg-white/10 rounded animate-pulse" />
-              <div className="h-9 w-24 bg-white/10 rounded animate-pulse" />
+            <div className="flex gap-2">
+              <Skeleton className="h-10 w-28 rounded-xl bg-muted/35" />
+              <Skeleton className="h-10 w-24 rounded-xl bg-muted/35" />
             </div>
           </div>
-        </div>
-      </div>
-
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats skeleton */}
-        <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="panel-frosted rounded-lg p-4">
-              <div className="h-4 w-20 bg-white/10 rounded mb-2 animate-pulse" />
-              <div className="h-8 w-12 bg-white/10 rounded animate-pulse" />
-            </div>
-          ))}
-        </div>
-
-        {/* Content skeleton */}
-        <div className="space-y-6">
-          <div className="panel-frosted rounded-lg p-6">
-            <div className="h-6 w-32 bg-white/10 rounded mb-4 animate-pulse" />
-            <div className="space-y-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="h-20 bg-white/10 rounded animate-pulse" />
-              ))}
-            </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
+            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
+            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
           </div>
+          <Skeleton className="h-12 w-full max-w-md rounded-xl bg-muted/35" />
+          <Skeleton className="h-[420px] w-full rounded-2xl bg-muted/30" />
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/components/dashboard/client-dashboard-skeleton.tsx
+++ b/components/dashboard/client-dashboard-skeleton.tsx
@@ -1,88 +1,91 @@
+import { PageShell } from "@/components/layout/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export function ClientDashboardSkeleton() {
   return (
-    <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient text-white">
-      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 lg:px-8 space-y-8">
-        {/* Header */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-64 bg-white/10" />
-            <Skeleton className="h-4 w-80 bg-white/10" />
-          </div>
-          <div className="flex gap-3">
-            <Skeleton className="h-10 w-28 rounded-full bg-white/10" />
-            <Skeleton className="h-10 w-36 rounded-full bg-white/10" />
-          </div>
-        </div>
-
-        {/* Stats grid */}
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              // eslint-disable-next-line react/no-array-index-key
-              key={i}
-              className="panel-frosted card-backlit rounded-2xl p-4"
-            >
-              <Skeleton className="h-4 w-24 bg-white/10" />
-              <div className="mt-3 flex items-end justify-between">
-                <Skeleton className="h-8 w-16 bg-white/10" />
-                <Skeleton className="h-6 w-10 bg-white/10" />
-              </div>
-              <Skeleton className="mt-4 h-3 w-28 bg-white/10" />
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
+      <div className="container mx-auto px-4 py-3 sm:px-6 sm:py-6 lg:px-8">
+        <div className="mx-auto w-full max-w-6xl space-y-8">
+          {/* Header */}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-2">
+              <Skeleton className="h-8 w-64 rounded-lg bg-muted/40" />
+              <Skeleton className="h-4 w-80 max-w-full rounded-lg bg-muted/35" />
             </div>
-          ))}
-        </div>
-
-        {/* Main panels */}
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          {Array.from({ length: 2 }).map((_, i) => (
-            <div
-              // eslint-disable-next-line react/no-array-index-key
-              key={i}
-              className="panel-frosted card-backlit rounded-2xl"
-            >
-              <div className="p-6 space-y-3">
-                <div className="flex items-center justify-between">
-                  <Skeleton className="h-6 w-40 bg-white/10" />
-                  <Skeleton className="h-6 w-16 rounded-full bg-white/10" />
-                </div>
-                <Skeleton className="h-4 w-64 bg-white/10" />
-              </div>
-              <div className="px-6 pb-6 space-y-4">
-                {Array.from({ length: 3 }).map((__, j) => (
-                  <div
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={j}
-                    className="flex items-center gap-4 rounded-xl border border-border/35 bg-card/35 p-4"
-                  >
-                    <Skeleton className="h-12 w-12 rounded-lg bg-white/10" />
-                    <div className="flex-1 space-y-2">
-                      <Skeleton className="h-4 w-48 bg-white/10" />
-                      <Skeleton className="h-3 w-64 bg-white/10" />
-                    </div>
-                    <Skeleton className="h-4 w-16 bg-white/10" />
-                  </div>
-                ))}
-              </div>
+            <div className="flex gap-3">
+              <Skeleton className="h-10 w-28 rounded-xl bg-muted/35" />
+              <Skeleton className="h-10 w-36 rounded-xl bg-muted/35" />
             </div>
-          ))}
-        </div>
+          </div>
 
-        {/* Tabs placeholder */}
-        <div className="panel-frosted card-backlit rounded-2xl p-6 space-y-4">
-          <div className="flex flex-wrap gap-2">
+          {/* Stats grid */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {Array.from({ length: 4 }).map((_, i) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <Skeleton key={i} className="h-9 w-28 rounded-full bg-white/10" />
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                className="panel-frosted card-backlit rounded-2xl p-4"
+              >
+                <Skeleton className="h-4 w-24 rounded-lg bg-muted/35" />
+                <div className="mt-3 flex items-end justify-between">
+                  <Skeleton className="h-8 w-16 rounded-lg bg-muted/40" />
+                  <Skeleton className="h-6 w-10 rounded-lg bg-muted/35" />
+                </div>
+                <Skeleton className="mt-4 h-3 w-28 rounded-lg bg-muted/30" />
+              </div>
             ))}
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Skeleton className="h-40 w-full rounded-xl bg-white/10" />
-            <Skeleton className="h-40 w-full rounded-xl bg-white/10" />
+
+          {/* Main panels */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                className="panel-frosted card-backlit rounded-2xl"
+              >
+                <div className="space-y-3 p-6">
+                  <div className="flex items-center justify-between">
+                    <Skeleton className="h-6 w-40 rounded-lg bg-muted/40" />
+                    <Skeleton className="h-6 w-16 rounded-full bg-muted/35" />
+                  </div>
+                  <Skeleton className="h-4 w-64 max-w-full rounded-lg bg-muted/35" />
+                </div>
+                <div className="space-y-4 px-6 pb-6">
+                  {Array.from({ length: 3 }).map((__, j) => (
+                    <div
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={j}
+                      className="flex items-center gap-4 rounded-xl border border-border/35 bg-card/35 p-4"
+                    >
+                      <Skeleton className="h-12 w-12 rounded-lg bg-muted/35" />
+                      <div className="flex-1 space-y-2">
+                        <Skeleton className="h-4 w-48 max-w-full rounded-lg bg-muted/40" />
+                        <Skeleton className="h-3 w-64 max-w-full rounded-lg bg-muted/30" />
+                      </div>
+                      <Skeleton className="h-4 w-16 rounded-lg bg-muted/35" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Tabs placeholder */}
+          <div className="panel-frosted card-backlit space-y-4 rounded-2xl p-6">
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                // eslint-disable-next-line react/no-array-index-key
+                <Skeleton key={i} className="h-9 w-28 rounded-full bg-muted/35" />
+              ))}
+            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Skeleton className="h-40 w-full rounded-xl bg-muted/30" />
+              <Skeleton className="h-40 w-full rounded-xl bg-muted/30" />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/components/dashboard/filters-sheet.tsx
+++ b/components/dashboard/filters-sheet.tsx
@@ -51,14 +51,14 @@ export function FiltersSheet({
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="truncate text-base font-semibold">{title}</p>
-                  <p className="truncate text-xs text-gray-300">Refine results</p>
+                  <p className="truncate text-xs text-[var(--oklch-text-tertiary)]">Refine results</p>
                 </div>
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon"
                   data-testid="filters-sheet-close"
-                  className="h-10 w-10 shrink-0 text-white hover:bg-white/10"
+                  className="h-10 w-10 shrink-0 text-[var(--oklch-text-primary)] hover:bg-white/10"
                   onClick={() => onOpenChange(false)}
                   aria-label="Close filters"
                 >

--- a/components/dashboard/secondary-action-link.tsx
+++ b/components/dashboard/secondary-action-link.tsx
@@ -13,7 +13,7 @@ export function SecondaryActionLink({ href, children, className }: SecondaryActi
   return (
     <Link
       href={href}
-      className={`text-sm text-gray-300 underline-offset-4 hover:text-white hover:underline ${className ?? ""}`.trim()}
+      className={`text-sm text-[var(--oklch-text-secondary)] underline-offset-4 hover:text-[var(--oklch-text-primary)] hover:underline ${className ?? ""}`.trim()}
     >
       {children}
     </Link>

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 10, 2026
+**Last Updated:** April 11, 2026
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 


### PR DESCRIPTION
What broke

There was no single production "break" driving this merge. **`main` is materially behind `develop`**, and the latest `develop` work (including this batch) continues the **lifted / frosted visual system** and **OKLCH token typography** so dashboards, client terminals, public gigs surfaces, admin tools, and loading shells do not fall back to flat gray slabs or inconsistent text contrast.

Why it broke

The app evolved on **`develop`** (features, admin flows, gigs/reference links, auth shell work, observability, etc.) while **`main`** stayed on an older baseline. Stakeholder feedback also pushed a **cohesive premium dark-glass language**; ad hoc Tailwind grays and light-mode dialog islands in admin moderation were visually and semantically out of step with the rest of the product.

What we changed

**Branch scope (important):** This PR merges **`develop` → `main`**. It includes **many commits** already on `develop` (features, fixes, docs, tests—not only the latest UI commit). The **latest commit** on `develop` is:

- `fix(ui): extend oklch tokens and lifted shells across dashboards and admin` — OKLCH text tokens across Career Builder / talent dashboards and related client surfaces; frosted **`CreateGigForm`**; admin **moderation** queue + dark-native review dialog; **`ClientDashboardSkeleton`** + **`settings/loading`** aligned with **`PageShell`**; shared **`SecondaryActionLink`** / **`FiltersSheet`**; **`MVP_STATUS_NOTION.md`** + docs index date.

Prior `develop` work in this delta also includes (non-exhaustive): application-flow polish, admin terminals, reference links on opportunities, lifted atmosphere for flows, gig terminology, booking/notifications, Sentry/logging hygiene, and numerous other fixes listed in `git log main..develop`.

How we proved it

- `npm run schema:verify:comprehensive` — pass  
- `npm run types:check` — pass  
- `npm run build` — pass (Next.js 15.5.13 production build)  
- `npm run lint` — pass  

Pre-commit hook on commit also re-ran guards + build + lint — **passed**.

Manual browser QA was **not** re-run as part of this ship (rely on CI/staging smoke after merge).

Docs updated: yes

- `MVP_STATUS_NOTION.md` — April 11, 2026 entry for OKLCH + frosted pass; P0/P1 next steps.  
- `docs/DOCUMENTATION_INDEX.md` — **Last Updated** set to April 11, 2026.

Risk + rollback

**Risk level:** Med — large merge surface (`develop` >> `main`); UI-only risk is mostly visual/regression on edge routes; functional risk depends on accumulated feature changes on `develop`.

**Rollback plan:** Revert the merge commit on `main` (or restore `main` to the previous SHA) and redeploy; keep fixes on `develop` for a follow-up release if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad UI refactor across admin/client/talent/public gigs pages (shell wrappers, dialog/table chrome, skeletons) risks visual regressions and layout/scroll behavior changes, but does not materially alter business logic or data flows.
> 
> **Overview**
> Unifies **dashboard/admin/public gigs** surfaces around the lifted/frosted design system by replacing ad-hoc Tailwind grays with OKLCH token colors and standard panel styles (cards, tables, badges, buttons, empty states).
> 
> Adopts the shared `TotlAtmosphereShell`/`PageShell` wrappers more widely (client applications/bookings/gigs, client dashboard, talent dashboard, public `gigs` list + detail, settings and dashboard skeletons) to standardize ambient background/role-based styling and loading/error presentations.
> 
> Refreshes admin tools styling: `CreateGigForm` is rebuilt as a frosted/ambient page, and `admin/moderation` updates queue chrome and the review dialog to a dark-native frosted look; minor text-token updates land in shared components like `FiltersSheet` and docs (`MVP_STATUS_NOTION.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a5cdc3e4ca4cae4c32e9e591094fbbf2508cefa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->