### PR TITLE
fix(ui): premium glass pass on settings modal and billing

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,22 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Premium authenticated surfaces — settings, application modal, billing (April 11, 2026)**
+
+**UI / SETTINGS / TALENT** — April 11, 2026
+- ✅ **Application details modal (`components/application-details-modal.tsx`):** Frosted dialog and inner cards use `panel-frosted`, `--totl-surface-glass-strong`, and OKLCH text tokens; duplicate header close removed; application ID row is mobile-safe; "What happens next" copy is status-aware with single CTAs via `PATHS`.
+- ✅ **Settings sections:** `account-settings`, `basic-info`, `subscription-section`, `talent-details`, and `career-builder-section` use glass cards and glass inputs (`bg-white/5`, `border-white/10`); cohesive gradient primaries; sign-out and security alert surfaces match the dark glass band; subscription links use `PATHS` / `PREFIXES`.
+- ✅ **Talent billing + profile loading:** `app/talent/settings/billing/billing-settings.tsx` aligned with subscription glass/OKLCH; `app/talent/profile/loading.tsx` uses a frosted skeleton shell.
+- ✅ **Subscription badge styling:** `getSubscriptionStatusColor` in `lib/subscription.ts` returns border/background/text classes that read correctly on dark glass (settings + billing).
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — all green (ship run, April 11, 2026).
+
+**Next (P0):** PR **develop → main**; smoke **`/settings`**, **talent dashboard → application details modal**, **`/talent/settings/billing`**, **talent profile** loading.
+
+**Next (P1):** Mobile spot-check for any remaining gray-heavy secondary routes; align stragglers with `panel-frosted` + OKLCH metadata scale.
+
+---
+
 ## 🚀 **Latest: ViZB catch-up — bookings, admin terminals, gig success, settings shells (April 11, 2026)**
 
 **UI / VIZB** — April 11, 2026

--- a/app/settings/sections/account-settings.tsx
+++ b/app/settings/sections/account-settings.tsx
@@ -22,6 +22,15 @@ import type { Database } from "@/types/supabase";
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
 type MinimalProfile = Pick<Profile, "role" | "subscription_status" | "subscription_plan" | "subscription_current_period_end">;
 
+const settingsGlassCard =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none";
+const fieldInput =
+  "bg-white/5 border-white/10 text-white placeholder:text-[var(--oklch-text-tertiary)]";
+const fieldInputError =
+  "border-red-500/80 bg-white/5 text-white placeholder:text-[var(--oklch-text-tertiary)]";
+const fieldDisabled =
+  "border-white/10 bg-white/[0.04] text-[var(--oklch-text-tertiary)] opacity-90";
+
 const passwordSchema = z
   .object({
     currentPassword: z.string().min(1, "Current password is required"),
@@ -113,12 +122,12 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
     if (/[0-9]/.test(password)) strength++;
     if (/[^A-Za-z0-9]/.test(password)) strength++;
 
-    const colors = ["bg-red-500", "bg-orange-500", "bg-yellow-500", "bg-blue-500", "bg-green-500"];
+    const colors = ["bg-red-500", "bg-orange-500", "bg-yellow-500", "bg-blue-500", "bg-emerald-500"];
     const texts = ["Very Weak", "Weak", "Fair", "Good", "Strong"];
 
     return {
       strength: Math.min(strength, 5),
-      color: colors[strength - 1] || "bg-gray-200",
+      color: colors[strength - 1] || "bg-white/25",
       text: texts[strength - 1] || "",
     };
   };
@@ -146,49 +155,44 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
   return (
     <div className="space-y-6">
       {/* Account Information */}
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-white">Account Information</CardTitle>
-          <CardDescription className="text-gray-400">
+      <Card className={settingsGlassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-lg font-semibold text-white">Account information</CardTitle>
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
             Your account details and verification status
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <Label className="text-gray-300">Email Address</Label>
-              <Input
-                value={user.email || ""}
-                disabled
-                className="bg-gray-700 border-gray-600 text-gray-400"
-              />
+              <Label className="text-[var(--oklch-text-secondary)]">Email address</Label>
+              <Input value={user.email || ""} disabled className={fieldDisabled} />
             </div>
             <div className="space-y-2">
-              <Label className="text-gray-300">Account Created</Label>
+              <Label className="text-[var(--oklch-text-secondary)]">Account created</Label>
               <Input
                 value={user.created_at ? new Date(user.created_at).toLocaleDateString() : "Unknown"}
                 disabled
-                className="bg-gray-700 border-gray-600 text-gray-400"
+                className={fieldDisabled}
               />
             </div>
           </div>
 
-          <Alert className="bg-gray-700 border-gray-600">
-            <AlertTriangle className="h-4 w-4 text-yellow-400" />
-            <AlertDescription className="text-gray-300">
-              For security reasons, email changes require contacting support. Password changes are
-              handled securely through Supabase authentication.
+          <Alert className="border-amber-500/25 bg-amber-500/10 text-[var(--oklch-text-secondary)]">
+            <AlertTriangle className="h-4 w-4 text-amber-400" />
+            <AlertDescription>
+              Email changes require support. Password updates use secure authentication.
             </AlertDescription>
           </Alert>
         </CardContent>
       </Card>
 
       {/* Password Change */}
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-white">Change Password</CardTitle>
-          <CardDescription className="text-gray-400">
-            Update your account password securely
+      <Card className={settingsGlassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-lg font-semibold text-white">Change password</CardTitle>
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
+            Update your password securely
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -196,9 +200,11 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
             <div className="space-y-2">
               <Label
                 htmlFor="currentPassword"
-                className={errors.currentPassword ? "text-red-400" : "text-gray-300"}
+                className={
+                  errors.currentPassword ? "text-red-400" : "text-[var(--oklch-text-secondary)]"
+                }
               >
-                Current Password
+                Current password
               </Label>
               <div className="relative">
                 <Input
@@ -206,18 +212,14 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
                   type={showCurrentPassword ? "text" : "password"}
                   placeholder="Enter your current password"
                   {...register("currentPassword")}
-                  className={
-                    errors.currentPassword
-                      ? "border-red-500 bg-gray-700 text-white"
-                      : "bg-gray-700 border-gray-600 text-white"
-                  }
+                  className={errors.currentPassword ? fieldInputError : fieldInput}
                   disabled={isSubmitting}
                 />
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-gray-400"
+                  className="absolute right-0 top-0 h-full px-3 py-2 text-[var(--oklch-text-tertiary)] hover:bg-transparent hover:text-white"
                   onClick={() => setShowCurrentPassword(!showCurrentPassword)}
                 >
                   {showCurrentPassword ? (
@@ -235,9 +237,9 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
             <div className="space-y-2">
               <Label
                 htmlFor="newPassword"
-                className={errors.newPassword ? "text-red-400" : "text-gray-300"}
+                className={errors.newPassword ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
               >
-                New Password
+                New password
               </Label>
               <div className="relative">
                 <Input
@@ -245,18 +247,14 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
                   type={showNewPassword ? "text" : "password"}
                   placeholder="Enter your new password"
                   {...register("newPassword")}
-                  className={
-                    errors.newPassword
-                      ? "border-red-500 bg-gray-700 text-white"
-                      : "bg-gray-700 border-gray-600 text-white"
-                  }
+                  className={errors.newPassword ? fieldInputError : fieldInput}
                   disabled={isSubmitting}
                 />
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-gray-400"
+                  className="absolute right-0 top-0 h-full px-3 py-2 text-[var(--oklch-text-tertiary)] hover:bg-transparent hover:text-white"
                   onClick={() => setShowNewPassword(!showNewPassword)}
                 >
                   {showNewPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -270,40 +268,32 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
               {newPassword && (
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <div className="flex-1 bg-gray-700 rounded-full h-2">
+                    <div className="h-2 flex-1 rounded-full bg-white/10">
                       <div
                         className={`h-2 rounded-full transition-all duration-300 ${passwordStrength.color}`}
                         style={{ width: `${(passwordStrength.strength / 5) * 100}%` }}
                       />
                     </div>
-                    <span className="text-sm text-gray-300">{passwordStrength.text}</span>
+                    <span className="text-sm text-[var(--oklch-text-secondary)]">
+                      {passwordStrength.text}
+                    </span>
                   </div>
-                  <div className="text-xs text-gray-400 space-y-1">
-                    <p>Password must contain:</p>
-                    <ul className="list-disc list-inside space-y-1">
-                      <li className={newPassword.length >= 8 ? "text-green-400" : "text-gray-500"}>
+                  <div className="space-y-1 text-xs text-[var(--oklch-text-tertiary)]">
+                    <p className="text-[var(--oklch-text-secondary)]">Password must contain:</p>
+                    <ul className="list-inside list-disc space-y-1">
+                      <li className={newPassword.length >= 8 ? "text-emerald-400" : ""}>
                         At least 8 characters
                       </li>
-                      <li
-                        className={/[A-Z]/.test(newPassword) ? "text-green-400" : "text-gray-500"}
-                      >
+                      <li className={/[A-Z]/.test(newPassword) ? "text-emerald-400" : ""}>
                         One uppercase letter
                       </li>
-                      <li
-                        className={/[a-z]/.test(newPassword) ? "text-green-400" : "text-gray-500"}
-                      >
+                      <li className={/[a-z]/.test(newPassword) ? "text-emerald-400" : ""}>
                         One lowercase letter
                       </li>
-                      <li
-                        className={/[0-9]/.test(newPassword) ? "text-green-400" : "text-gray-500"}
-                      >
+                      <li className={/[0-9]/.test(newPassword) ? "text-emerald-400" : ""}>
                         One number
                       </li>
-                      <li
-                        className={
-                          /[^A-Za-z0-9]/.test(newPassword) ? "text-green-400" : "text-gray-500"
-                        }
-                      >
+                      <li className={/[^A-Za-z0-9]/.test(newPassword) ? "text-emerald-400" : ""}>
                         One special character
                       </li>
                     </ul>
@@ -315,9 +305,11 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
             <div className="space-y-2">
               <Label
                 htmlFor="confirmPassword"
-                className={errors.confirmPassword ? "text-red-400" : "text-gray-300"}
+                className={
+                  errors.confirmPassword ? "text-red-400" : "text-[var(--oklch-text-secondary)]"
+                }
               >
-                Confirm New Password
+                Confirm new password
               </Label>
               <div className="relative">
                 <Input
@@ -325,18 +317,14 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
                   type={showConfirmPassword ? "text" : "password"}
                   placeholder="Confirm your new password"
                   {...register("confirmPassword")}
-                  className={
-                    errors.confirmPassword
-                      ? "border-red-500 bg-gray-700 text-white"
-                      : "bg-gray-700 border-gray-600 text-white"
-                  }
+                  className={errors.confirmPassword ? fieldInputError : fieldInput}
                   disabled={isSubmitting}
                 />
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent text-gray-400"
+                  className="absolute right-0 top-0 h-full px-3 py-2 text-[var(--oklch-text-tertiary)] hover:bg-transparent hover:text-white"
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
                   {showConfirmPassword ? (
@@ -355,9 +343,9 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
               <Button
                 type="submit"
                 disabled={isSubmitting || !isDirty}
-                className="min-w-[100px] bg-white text-black hover:bg-gray-200"
+                className="min-w-[120px] border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 disabled:opacity-50"
               >
-                {isSubmitting ? "Updating..." : "Update Password"}
+                {isSubmitting ? "Updating..." : "Update password"}
               </Button>
             </div>
           </form>
@@ -371,19 +359,19 @@ export function AccountSettingsSection({ user, profile }: AccountSettingsSection
       <CareerBuilderSection userEmail={user.email} />
 
       {/* Sign Out */}
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-white">Sign Out</CardTitle>
-          <CardDescription className="text-gray-400">
-            Sign out of your account securely
+      <Card className={settingsGlassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-lg font-semibold text-white">Sign out</CardTitle>
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
+            End your session on this device
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Button
             onClick={handleSignOut}
             disabled={isSigningOut}
-            variant="destructive"
-            className="w-full md:w-auto bg-red-600 hover:bg-red-700 text-white"
+            variant="outline"
+            className="w-full border-red-500/40 bg-red-500/10 text-red-200 hover:bg-red-500/20 hover:text-white md:w-auto"
           >
             {isSigningOut ? (
               <>

--- a/app/settings/sections/basic-info.tsx
+++ b/app/settings/sections/basic-info.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { User } from "@supabase/supabase-js";
+import { User as UserIcon } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -24,6 +25,15 @@ const basicInfoSchema = z.object({
 });
 
 type BasicInfoFormData = z.infer<typeof basicInfoSchema>;
+
+const settingsGlassCard =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none";
+const fieldInput =
+  "bg-white/5 border-white/10 text-white placeholder:text-[var(--oklch-text-tertiary)]";
+const fieldInputError =
+  "border-red-500/80 bg-white/5 text-white placeholder:text-[var(--oklch-text-tertiary)]";
+const fieldDisabled =
+  "border-white/10 bg-white/[0.04] text-[var(--oklch-text-tertiary)] opacity-90";
 
 interface BasicInfoSectionProps {
   user: User;
@@ -91,50 +101,40 @@ export function BasicInfoSection({ user, profile }: BasicInfoSectionProps) {
   };
 
   return (
-    <Card className="bg-gray-800 border-gray-700">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-white">
-          <div className="h-5 w-5">👤</div>
-          Basic Information
+    <Card className={settingsGlassCard}>
+      <CardHeader className="space-y-1">
+        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
+          <UserIcon className="h-5 w-5 text-[var(--oklch-accent)]" aria-hidden />
+          Basic information
         </CardTitle>
-        <CardDescription className="text-gray-400">
-          Update your basic profile information
+        <CardDescription className="text-[var(--oklch-text-secondary)]">
+          Update how your name appears across TOTL
         </CardDescription>
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="email" className="text-gray-300">
+            <Label htmlFor="email" className="text-[var(--oklch-text-secondary)]">
               Email
             </Label>
-            <Input
-              id="email"
-              type="email"
-              value={user.email || ""}
-              disabled
-              className="bg-gray-700 border-gray-600 text-gray-400"
-            />
-            <p className="text-sm text-gray-400">
-              Email cannot be changed. Contact support if you need to update your email.
+            <Input id="email" type="email" value={user.email || ""} disabled className={fieldDisabled} />
+            <p className="text-sm text-[var(--oklch-text-tertiary)]">
+              Email can&apos;t be changed here. Contact support if you need a new address on file.
             </p>
           </div>
 
           <div className="space-y-2">
             <Label
               htmlFor="display_name"
-              className={errors.display_name ? "text-red-400" : "text-gray-300"}
+              className={errors.display_name ? "text-red-400" : "text-[var(--oklch-text-secondary)]"}
             >
-              Display Name *
+              Display name *
             </Label>
             <Input
               id="display_name"
               placeholder="Enter your display name"
               {...register("display_name")}
-              className={
-                errors.display_name
-                  ? "border-red-500 bg-gray-700 text-white"
-                  : "bg-gray-700 border-gray-600 text-white"
-              }
+              className={errors.display_name ? fieldInputError : fieldInput}
               disabled={isSubmitting}
             />
             {errors.display_name && (
@@ -142,21 +142,21 @@ export function BasicInfoSection({ user, profile }: BasicInfoSectionProps) {
             )}
           </div>
 
-          <div className="flex items-center justify-between pt-4">
-            <div className="text-sm text-gray-400">
+          <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-[var(--oklch-text-secondary)]">
               {profile.email_verified ? (
-                <span className="text-green-400">✅ Email verified</span>
+                <span className="text-emerald-400">Email verified</span>
               ) : (
-                <span className="text-yellow-400">⚠️ Email not verified</span>
+                <span className="text-amber-400">Email not verified — check your inbox</span>
               )}
             </div>
 
             <Button
               type="submit"
               disabled={isSubmitting || !isDirty}
-              className="min-w-[100px] bg-white text-black hover:bg-gray-200"
+              className="min-w-[120px] shrink-0 border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 disabled:opacity-50"
             >
-              {isSubmitting ? "Saving..." : "Save Changes"}
+              {isSubmitting ? "Saving..." : "Save changes"}
             </Button>
           </div>
         </form>

--- a/app/settings/sections/career-builder-section.tsx
+++ b/app/settings/sections/career-builder-section.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PATHS } from "@/lib/constants/routes";
 import { logger } from "@/lib/utils/logger";
 
 interface ApplicationStatus {
@@ -19,6 +20,9 @@ interface ApplicationStatus {
 interface CareerBuilderSectionProps {
   userEmail: string | undefined;
 }
+
+const glassCard =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none";
 
 export function CareerBuilderSection({ userEmail }: CareerBuilderSectionProps) {
   const { user, profile } = useAuth();
@@ -72,23 +76,32 @@ export function CareerBuilderSection({ userEmail }: CareerBuilderSectionProps) {
     switch (status) {
       case "approved":
         return (
-          <Badge className="bg-green-600 text-white">
-            <CheckCircle className="h-3 w-3 mr-1" />
+          <Badge
+            variant="outline"
+            className="border-emerald-500/35 bg-emerald-500/15 font-medium text-emerald-200"
+          >
+            <CheckCircle className="mr-1 h-3 w-3" />
             Approved
           </Badge>
         );
       case "pending":
         return (
-          <Badge className="bg-yellow-600 text-white">
-            <Clock className="h-3 w-3 mr-1" />
-            Under Review
+          <Badge
+            variant="outline"
+            className="border-amber-500/35 bg-amber-500/15 font-medium text-amber-200"
+          >
+            <Clock className="mr-1 h-3 w-3" />
+            Under review
           </Badge>
         );
       case "rejected":
         return (
-          <Badge className="bg-red-600 text-white">
-            <XCircle className="h-3 w-3 mr-1" />
-            Rejected
+          <Badge
+            variant="outline"
+            className="border-red-500/35 bg-red-500/15 font-medium text-red-200"
+          >
+            <XCircle className="mr-1 h-3 w-3" />
+            Not approved
           </Badge>
         );
       default:
@@ -99,83 +112,102 @@ export function CareerBuilderSection({ userEmail }: CareerBuilderSectionProps) {
   const getStatusMessage = (status: string | null) => {
     switch (status) {
       case "approved":
-        return "Your application has been approved! You now have access to the Career Builder dashboard.";
+        return "Your application has been approved. Open the Career Builder dashboard to post work and hire talent.";
       case "pending":
-        return "Your application is being reviewed by our team. You'll be notified when we have an update.";
+        return "Our team is reviewing your application. We’ll notify you when there’s an update.";
       case "rejected":
-        return "Your previous application was not approved. Please reach out to hello@thetotlagency.com to reapply.";
+        return "This application wasn’t approved. Reach out to hello@thetotlagency.com if you’d like to discuss next steps.";
       default:
         return null;
     }
   };
 
   return (
-    <Card className="bg-gray-800 border-gray-700">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-white">
-          <Briefcase className="h-5 w-5" />
+    <Card className={glassCard}>
+      <CardHeader className="space-y-1">
+        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
+          <Briefcase className="h-5 w-5 text-[var(--oklch-accent)]" aria-hidden />
           Become a Career Builder
         </CardTitle>
-        <CardDescription className="text-gray-400">
+        <CardDescription className="text-[var(--oklch-text-secondary)]">
           Post opportunities and hire talent through TOTL Agency
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {isLoading ? (
-          <div className="text-center py-4">
-            <p className="text-gray-400">Checking application status...</p>
+          <div className="py-6 text-center">
+            <p className="text-sm text-[var(--oklch-text-secondary)]">Checking application status…</p>
           </div>
         ) : applicationStatus?.status ? (
           <>
-            <div className="flex items-center justify-between">
-              <span className="text-gray-300 font-medium">Application Status:</span>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Status</span>
               {getStatusBadge(applicationStatus.status)}
             </div>
 
             {getStatusMessage(applicationStatus.status) && (
-              <Alert className="bg-gray-700 border-gray-600">
-                <AlertDescription className="text-gray-300">
-                  {getStatusMessage(applicationStatus.status)}
-                </AlertDescription>
+              <Alert className="border-white/10 bg-white/[0.04] text-[var(--oklch-text-secondary)]">
+                <AlertDescription>{getStatusMessage(applicationStatus.status)}</AlertDescription>
               </Alert>
             )}
 
             {applicationStatus.status === "approved" && (
-              <Button asChild className="w-full bg-green-600 hover:bg-green-700 text-white">
-                <Link href="/client/dashboard">
-                  Go to Career Builder Dashboard
-                  <ArrowRight className="h-4 w-4 ml-2" />
+              <Button
+                asChild
+                className="w-full border-0 bg-gradient-to-r from-emerald-500 to-teal-600 text-white hover:from-emerald-400 hover:to-teal-500"
+              >
+                <Link href={PATHS.CLIENT_DASHBOARD}>
+                  Open Career Builder
+                  <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             )}
 
+            {applicationStatus.status === "pending" && (
+              <Button
+                asChild
+                variant="outline"
+                className="w-full border-white/15 bg-white/5 text-white hover:bg-white/10"
+              >
+                <Link href={PATHS.TALENT_DASHBOARD}>Back to talent dashboard</Link>
+              </Button>
+            )}
+
             {applicationStatus.status === "rejected" && (
-              <Button asChild variant="outline" className="w-full border-gray-600 text-white hover:bg-gray-700">
-                <Link href="/client/apply">
-                  Reapply to be a Career Builder
-                  <ArrowRight className="h-4 w-4 ml-2" />
+              <Button
+                asChild
+                variant="outline"
+                className="w-full border-white/15 bg-white/5 text-white hover:bg-white/10"
+              >
+                <Link href={PATHS.CLIENT_APPLY}>
+                  Reapply
+                  <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>
             )}
           </>
         ) : (
           <>
-            <div className="text-sm text-gray-400 space-y-2">
+            <div className="space-y-2 text-sm text-[var(--oklch-text-secondary)]">
               <p>
-                Career Builders can post opportunities and hire talent through TOTL Agency. Apply now to join our exclusive network.
+                Career Builders post opportunities and book talent on TOTL. Apply once to unlock the
+                client workspace.
               </p>
-              <ul className="list-disc list-inside space-y-1 ml-2">
+              <ul className="ml-1 list-inside list-disc space-y-1 marker:text-[var(--oklch-text-tertiary)]">
                 <li>Post unlimited opportunities</li>
-                <li>Access our premium talent roster</li>
+                <li>Access our talent roster</li>
                 <li>Manage applications and bookings</li>
-                <li>Direct communication with talent</li>
+                <li>Message talent directly</li>
               </ul>
             </div>
 
-            <Button asChild className="w-full bg-white text-black hover:bg-gray-200">
-              <Link href="/client/apply">
+            <Button
+              asChild
+              className="w-full border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400"
+            >
+              <Link href={PATHS.CLIENT_APPLY}>
                 Apply to be a Career Builder
-                <ArrowRight className="h-4 w-4 ml-2" />
+                <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
           </>
@@ -184,4 +216,3 @@ export function CareerBuilderSection({ userEmail }: CareerBuilderSectionProps) {
     </Card>
   );
 }
-

--- a/app/settings/sections/subscription-section.tsx
+++ b/app/settings/sections/subscription-section.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PATHS, PREFIXES } from "@/lib/constants/routes";
 import {
   getSubscriptionStatusText,
   getSubscriptionStatusColor,
@@ -12,6 +13,7 @@ import {
   isActiveSubscriber,
   needsSubscription,
 } from "@/lib/subscription";
+import { cn } from "@/lib/utils/utils";
 import type { Database } from "@/types/supabase";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
@@ -30,14 +32,14 @@ export function SubscriptionSection({ profile }: SubscriptionSectionProps) {
   const getStatusIcon = () => {
     switch (profile.subscription_status) {
       case "active":
-        return <CheckCircle className="h-4 w-4 text-green-500" />;
+        return <CheckCircle className="h-4 w-4 text-emerald-400" />;
       case "past_due":
-        return <AlertCircle className="h-4 w-4 text-yellow-500" />;
+        return <AlertCircle className="h-4 w-4 text-amber-400" />;
       case "canceled":
       case "none":
-        return <Clock className="h-4 w-4 text-gray-500" />;
+        return <Clock className="h-4 w-4 text-[var(--oklch-text-tertiary)]" />;
       default:
-        return <Clock className="h-4 w-4 text-gray-500" />;
+        return <Clock className="h-4 w-4 text-[var(--oklch-text-tertiary)]" />;
     }
   };
 
@@ -51,67 +53,78 @@ export function SubscriptionSection({ profile }: SubscriptionSectionProps) {
   };
 
   return (
-    <Card className="bg-gray-800 border-gray-700">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-white">
+    <Card className="panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none">
+      <CardHeader className="space-y-1">
+        <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
           {getStatusIcon()}
-          Subscription Status
+          Subscription
         </CardTitle>
-        <CardDescription className="text-gray-400">
+        <CardDescription className="text-[var(--oklch-text-secondary)]">
           Manage your TOTL Agency subscription to unlock premium features
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <span className="text-gray-300 font-medium">Status:</span>
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Status</span>
           <Badge
-            variant={isActiveSubscriber(profile) ? "default" : "secondary"}
-            className={getSubscriptionStatusColor(profile.subscription_status)}
+            variant="outline"
+            className={cn("font-medium", getSubscriptionStatusColor(profile.subscription_status))}
           >
             {getSubscriptionStatusText(profile.subscription_status)}
           </Badge>
         </div>
 
         {profile.subscription_plan && (
-          <div className="flex items-center justify-between">
-            <span className="text-gray-300 font-medium">Plan:</span>
-            <span className="text-white">{getPlanDisplayName(profile.subscription_plan)}</span>
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Plan</span>
+            <span className="text-sm text-white sm:text-right">
+              {getPlanDisplayName(profile.subscription_plan)}
+            </span>
           </div>
         )}
 
         {profile.subscription_current_period_end && (
-          <div className="flex items-center justify-between">
-            <span className="text-gray-300 font-medium">
-              {isActiveSubscriber(profile) ? "Next billing date:" : "Ended on:"}
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+              {isActiveSubscriber(profile) ? "Next billing date" : "Ended on"}
             </span>
-            <span className="text-white">{formatDate(profile.subscription_current_period_end)}</span>
+            <span className="text-sm text-white sm:text-right">
+              {formatDate(profile.subscription_current_period_end)}
+            </span>
           </div>
         )}
 
-        <div className="pt-2 border-t border-gray-700">
+        <div className="border-t border-white/10 pt-4">
           {needsSubscription(profile) ? (
-            <Button asChild className="w-full bg-white text-black hover:bg-gray-200">
-              <Link href="/talent/subscribe">
-                <Star className="h-4 w-4 mr-2" />
-                Subscribe Now
+            <Button
+              asChild
+              className="w-full border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400"
+            >
+              <Link href={PATHS.TALENT_SUBSCRIBE}>
+                <Star className="mr-2 h-4 w-4" />
+                Subscribe now
               </Link>
             </Button>
           ) : (
-            <Button asChild variant="outline" className="w-full border-gray-600 text-white hover:bg-gray-700">
-              <Link href="/talent/settings/billing">
-                <CreditCard className="h-4 w-4 mr-2" />
-                Manage Subscription
+            <Button
+              asChild
+              variant="outline"
+              className="w-full border-white/15 bg-white/5 text-white hover:bg-white/10"
+            >
+              <Link href={`${PREFIXES.TALENT_SETTINGS}/billing`}>
+                <CreditCard className="mr-2 h-4 w-4" />
+                Manage subscription
               </Link>
             </Button>
           )}
         </div>
 
         {needsSubscription(profile) && (
-          <div className="text-sm text-gray-400 space-y-1">
-            <p className="font-medium text-gray-300">Premium features include:</p>
-            <ul className="list-disc list-inside space-y-1 ml-2">
+          <div className="space-y-2 text-sm text-[var(--oklch-text-secondary)]">
+            <p className="font-medium text-white">Premium includes</p>
+            <ul className="ml-1 list-inside list-disc space-y-1 marker:text-[var(--oklch-text-tertiary)]">
               <li>Apply to unlimited gigs</li>
-              <li>See full client details and contact info</li>
+              <li>Full client details and contact info</li>
               <li>Profile visible in client searches</li>
               <li>Priority support</li>
             </ul>

--- a/app/settings/sections/talent-details.tsx
+++ b/app/settings/sections/talent-details.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Sparkles } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -40,6 +41,13 @@ const talentSchema = z.object({
 });
 
 type TalentFormData = z.infer<typeof talentSchema>;
+
+const settingsGlassCard =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none";
+const fieldInput =
+  "bg-white/5 border-white/10 text-white placeholder:text-[var(--oklch-text-tertiary)]";
+const fieldInputError =
+  "border-red-500/80 bg-white/5 text-white placeholder:text-[var(--oklch-text-tertiary)]";
 
 interface TalentDetailsSectionProps {
   talent: Talent | null;
@@ -125,32 +133,33 @@ export function TalentDetailsSection({ talent }: TalentDetailsSectionProps) {
 
   return (
     <div className="space-y-6">
-      <Card className="bg-gray-800 border-gray-700">
-        <CardHeader>
-          <CardTitle className="text-white">Talent Details</CardTitle>
-          <CardDescription className="text-gray-400">
-            Update your talent-specific information
+      <Card className={settingsGlassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
+            <Sparkles className="h-5 w-5 text-[var(--oklch-accent)]" aria-hidden />
+            Talent details
+          </CardTitle>
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
+            Information clients see when you apply and get booked
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid min-w-0 grid-cols-1 gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <Label
                   htmlFor="first_name"
-                  className={errors.first_name ? "text-red-400" : "text-gray-300"}
+                  className={
+                    errors.first_name ? "text-red-400" : "text-[var(--oklch-text-secondary)]"
+                  }
                 >
-                  First Name *
+                  First name *
                 </Label>
                 <Input
                   id="first_name"
                   placeholder="Enter your first name"
                   {...register("first_name")}
-                  className={
-                    errors.first_name
-                      ? "border-red-500 bg-gray-700 text-white"
-                      : "bg-gray-700 border-gray-600 text-white"
-                  }
+                  className={errors.first_name ? fieldInputError : fieldInput}
                   disabled={isSubmitting}
                 />
                 {errors.first_name && (
@@ -161,19 +170,17 @@ export function TalentDetailsSection({ talent }: TalentDetailsSectionProps) {
               <div className="space-y-2">
                 <Label
                   htmlFor="last_name"
-                  className={errors.last_name ? "text-red-400" : "text-gray-300"}
+                  className={
+                    errors.last_name ? "text-red-400" : "text-[var(--oklch-text-secondary)]"
+                  }
                 >
-                  Last Name *
+                  Last name *
                 </Label>
                 <Input
                   id="last_name"
                   placeholder="Enter your last name"
                   {...register("last_name")}
-                  className={
-                    errors.last_name
-                      ? "border-red-500 bg-gray-700 text-white"
-                      : "bg-gray-700 border-gray-600 text-white"
-                  }
+                  className={errors.last_name ? fieldInputError : fieldInput}
                   disabled={isSubmitting}
                 />
                 {errors.last_name && (
@@ -183,7 +190,7 @@ export function TalentDetailsSection({ talent }: TalentDetailsSectionProps) {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="experience" className="text-gray-300">
+              <Label htmlFor="experience" className="text-[var(--oklch-text-secondary)]">
                 Experience
               </Label>
               <Textarea
@@ -192,17 +199,17 @@ export function TalentDetailsSection({ talent }: TalentDetailsSectionProps) {
                 {...register("experience")}
                 disabled={isSubmitting}
                 rows={4}
-                className="bg-gray-700 border-gray-600 text-white placeholder:text-gray-500"
+                className={`${fieldInput} min-h-[120px] resize-y`}
               />
             </div>
 
-            <div className="flex justify-end pt-4">
+            <div className="flex justify-end pt-2">
               <Button
                 type="submit"
                 disabled={isSubmitting || !isDirty}
-                className="min-w-[100px] bg-white text-black hover:bg-gray-200"
+                className="min-w-[120px] border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 disabled:opacity-50"
               >
-                {isSubmitting ? "Saving..." : "Save Changes"}
+                {isSubmitting ? "Saving..." : "Save changes"}
               </Button>
             </div>
           </form>

--- a/app/talent/profile/loading.tsx
+++ b/app/talent/profile/loading.tsx
@@ -6,20 +6,20 @@ export default function TalentProfileLoading() {
     <PageShell className="bg-black" containerClassName="max-w-3xl py-4 sm:py-6">
       <div className="space-y-6">
         <div className="space-y-2">
-          <Skeleton className="h-9 w-56 bg-gray-800" />
-          <Skeleton className="h-5 w-80 max-w-full bg-gray-800" />
+          <Skeleton className="h-9 w-56 max-w-full bg-white/10" />
+          <Skeleton className="h-5 w-80 max-w-full bg-white/10" />
         </div>
-        <div className="space-y-6 rounded-lg border border-gray-800 bg-gray-900 p-6">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <Skeleton className="h-10 w-full bg-gray-800" />
-            <Skeleton className="h-10 w-full bg-gray-800" />
-            <Skeleton className="h-10 w-full bg-gray-800" />
-            <Skeleton className="h-10 w-full bg-gray-800" />
+        <div className="panel-frosted space-y-6 rounded-2xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-4 sm:p-6">
+          <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+            <Skeleton className="h-10 w-full bg-white/10" />
+            <Skeleton className="h-10 w-full bg-white/10" />
+            <Skeleton className="h-10 w-full bg-white/10" />
+            <Skeleton className="h-10 w-full bg-white/10" />
           </div>
-          <Skeleton className="h-24 w-full bg-gray-800" />
+          <Skeleton className="h-24 w-full bg-white/10" />
           <div className="flex justify-end gap-2">
-            <Skeleton className="h-10 w-24 bg-gray-800" />
-            <Skeleton className="h-10 w-32 bg-gray-800" />
+            <Skeleton className="h-10 w-24 bg-white/10" />
+            <Skeleton className="h-10 w-32 bg-white/10" />
           </div>
         </div>
       </div>

--- a/app/talent/settings/billing/billing-settings.tsx
+++ b/app/talent/settings/billing/billing-settings.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { AlertCircle, CheckCircle, ChevronDown, ChevronUp, Clock, CreditCard, ExternalLink } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  CreditCard,
+  ExternalLink,
+} from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 
@@ -9,15 +17,17 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { PATHS } from "@/lib/constants/routes";
 import { isRedirectError } from "@/lib/is-redirect-error";
-import { 
-  getSubscriptionStatusText, 
-  getSubscriptionStatusColor, 
+import {
+  getSubscriptionStatusText,
+  getSubscriptionStatusColor,
   getPlanDisplayName,
   isActiveSubscriber,
   needsSubscription,
-  hasPaymentIssues
+  hasPaymentIssues,
 } from "@/lib/subscription";
+import { cn } from "@/lib/utils/utils";
 import type { Database } from "@/types/supabase";
 
 type Profile = Database["public"]["Tables"]["profiles"]["Row"];
@@ -35,6 +45,9 @@ interface BillingSettingsProps {
   profile: BillingProfile;
 }
 
+const glassCard =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] text-white shadow-none";
+
 export function BillingSettings({ profile }: BillingSettingsProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [showPlanDetails, setShowPlanDetails] = useState(isActiveSubscriber(profile));
@@ -47,180 +60,186 @@ export function BillingSettings({ profile }: BillingSettingsProps) {
       if (isRedirectError(error)) {
         throw error;
       }
-      console.error('Billing portal error:', error);
+      console.error("Billing portal error:", error);
       setIsLoading(false);
-      // You could add toast notification here
     }
   };
 
   const formatDate = (dateString: string | null) => {
-    if (!dateString) return 'N/A';
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
+    if (!dateString) return "N/A";
+    return new Date(dateString).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
     });
   };
 
-  const getStatusIcon = (status: Database['public']['Enums']['subscription_status']) => {
+  const getStatusIcon = (status: Database["public"]["Enums"]["subscription_status"]) => {
     switch (status) {
-      case 'active':
-        return <CheckCircle className="h-4 w-4 text-green-500" />;
-      case 'past_due':
-        return <AlertCircle className="h-4 w-4 text-yellow-500" />;
-      case 'canceled':
-      case 'none':
-        return <Clock className="h-4 w-4 text-gray-500" />;
+      case "active":
+        return <CheckCircle className="h-4 w-4 text-emerald-400" />;
+      case "past_due":
+        return <AlertCircle className="h-4 w-4 text-amber-400" />;
+      case "canceled":
+      case "none":
+        return <Clock className="h-4 w-4 text-[var(--oklch-text-tertiary)]" />;
       default:
-        return <Clock className="h-4 w-4 text-gray-500" />;
+        return <Clock className="h-4 w-4 text-[var(--oklch-text-tertiary)]" />;
     }
   };
 
   return (
     <div className="space-y-5 pb-20 sm:pb-0">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
+      <Card className={glassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
             {getStatusIcon(profile.subscription_status)}
-            Subscription Snapshot
+            Subscription snapshot
           </CardTitle>
-          <CardDescription>
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
             Current status of your TOTL Agency subscription.
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <span className="font-medium">Status:</span>
-            <Badge 
-              variant={isActiveSubscriber(profile) ? "default" : "secondary"}
-              className={getSubscriptionStatusColor(profile.subscription_status)}
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Status</span>
+            <Badge
+              variant="outline"
+              className={cn("font-medium", getSubscriptionStatusColor(profile.subscription_status))}
             >
               {getSubscriptionStatusText(profile.subscription_status)}
             </Badge>
           </div>
-          
+
           {profile.subscription_plan && (
-            <div className="flex items-center justify-between">
-              <span className="font-medium">Plan:</span>
-              <span>{getPlanDisplayName(profile.subscription_plan)}</span>
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Plan</span>
+              <span className="text-sm text-white sm:text-right">
+                {getPlanDisplayName(profile.subscription_plan)}
+              </span>
             </div>
           )}
-          
+
           {profile.subscription_current_period_end && (
-            <div className="flex items-center justify-between">
-              <span className="font-medium">
-                {isActiveSubscriber(profile) ? 'Next billing date:' : 'Ended on:'}
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+                {isActiveSubscriber(profile) ? "Next billing date" : "Ended on"}
               </span>
-              <span>{formatDate(profile.subscription_current_period_end)}</span>
+              <span className="text-sm text-white sm:text-right">
+                {formatDate(profile.subscription_current_period_end)}
+              </span>
             </div>
           )}
         </CardContent>
       </Card>
 
-      {/* Status-specific alerts */}
       {hasPaymentIssues(profile) && (
-        <Alert>
-          <AlertCircle className="h-4 w-4" />
+        <Alert className="border-amber-500/30 bg-amber-500/10 text-[var(--oklch-text-secondary)]">
+          <AlertCircle className="h-4 w-4 text-amber-400" />
           <AlertDescription>
-            Your payment is overdue. Please update your payment method to continue accessing premium features.
+            Your payment is overdue. Update your payment method in the billing portal to keep premium
+            access.
           </AlertDescription>
         </Alert>
       )}
 
       {needsSubscription(profile) && (
-        <Alert>
-          <AlertCircle className="h-4 w-4" />
+        <Alert className="border-white/10 bg-white/[0.04] text-[var(--oklch-text-secondary)]">
+          <AlertCircle className="h-4 w-4 text-[var(--oklch-text-tertiary)]" />
           <AlertDescription>
-              You don&apos;t have an active subscription. Subscribe to apply to gigs and access all premium features.
+            You don&apos;t have an active subscription. Subscribe to apply to gigs and unlock premium
+            features.
           </AlertDescription>
         </Alert>
       )}
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <CreditCard className="h-5 w-5" />
-            Billing Actions
+      <Card className={glassCard}>
+        <CardHeader className="space-y-1">
+          <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
+            <CreditCard className="h-5 w-5 text-[var(--oklch-accent)]" />
+            Billing actions
           </CardTitle>
-          <CardDescription>
-            Update your payment method, change plans, or cancel your subscription.
+          <CardDescription className="text-[var(--oklch-text-secondary)]">
+            Update payment methods, invoices, or your plan—handled securely by Stripe.
           </CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">
+        <CardContent className="space-y-3">
+          <p className="text-sm text-[var(--oklch-text-secondary)]">
             {profile.stripe_customer_id
-              ? "Open Stripe's secure billing portal to manage cards, invoices, and plan changes."
-              : "You haven't subscribed yet. Choose a plan to get started."}
+              ? "Open Stripe’s billing portal to manage cards, invoices, and plan changes."
+              : "You haven’t subscribed yet. Choose a plan to get started."}
           </p>
-          
-          <p className="text-xs text-muted-foreground">
-            You&apos;ll be redirected to Stripe&apos;s secure billing portal where you can update your payment method, 
-            download invoices, and manage your subscription.
+
+          <p className="text-xs text-[var(--oklch-text-tertiary)]">
+            You’ll be redirected to Stripe’s secure site. Nothing sensitive is stored in the browser.
           </p>
         </CardContent>
       </Card>
 
-      <div className="rounded-xl border border-gray-700/80 bg-gray-900/50 p-3">
+      <div className="panel-frosted rounded-xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-3">
         <Button
           type="button"
           variant="ghost"
-          className="h-auto w-full justify-between px-2 py-2 text-left text-gray-100 hover:bg-gray-800/80"
+          className="h-auto w-full justify-between px-2 py-2 text-left text-white hover:bg-white/10"
           onClick={() => setShowPlanDetails((current) => !current)}
         >
-          <span>{showPlanDetails ? "Hide plan details" : "Show plan details"}</span>
+          <span className="text-sm font-medium">
+            {showPlanDetails ? "Hide plan details" : "Show plan details"}
+          </span>
           {showPlanDetails ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
         </Button>
-        <p className="px-2 pt-1 text-xs text-gray-400">
-          Expand this section only when you need feature-level details.
+        <p className="px-2 pt-1 text-xs text-[var(--oklch-text-tertiary)]">
+          Expand when you want a refresher on what’s included.
         </p>
       </div>
 
       {showPlanDetails && isActiveSubscriber(profile) && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Premium Features</CardTitle>
-            <CardDescription>
-                What&apos;s included in your subscription
+        <Card className={glassCard}>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-lg font-semibold text-white">Premium features</CardTitle>
+            <CardDescription className="text-[var(--oklch-text-secondary)]">
+              Included with your subscription
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <ul className="space-y-2 text-sm">
+            <ul className="space-y-2 text-sm text-[var(--oklch-text-secondary)]">
               <li className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
+                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
                 Apply to unlimited gigs
               </li>
               <li className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                See full client details and contact information
+                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+                Full client details and contact information
               </li>
               <li className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
+                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
                 Profile visible in client searches
               </li>
               <li className="flex items-center gap-2">
-                <CheckCircle className="h-4 w-4 text-green-500" />
-                Priority support and faster responses
+                <CheckCircle className="h-4 w-4 shrink-0 text-emerald-400" />
+                Priority support
               </li>
             </ul>
           </CardContent>
         </Card>
       )}
 
-      <div className="sticky bottom-3 z-10 -mx-1 rounded-xl border border-gray-700 bg-black/95 p-3 backdrop-blur supports-[backdrop-filter]:bg-black/80">
+      <div className="sticky bottom-3 z-10 -mx-1 rounded-xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-3 backdrop-blur-md panel-frosted">
         {profile.stripe_customer_id ? (
           <Button
             onClick={handleManageSubscription}
             disabled={isLoading}
-            className="w-full"
+            className="w-full border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400 disabled:opacity-50"
           >
-            <ExternalLink className="h-4 w-4 mr-2" />
-            {isLoading ? 'Opening...' : 'Manage Subscription'}
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {isLoading ? "Opening…" : "Manage subscription"}
           </Button>
         ) : (
-          <Button asChild className="w-full">
-            <Link href="/talent/subscribe">
-              Choose Plan
-            </Link>
+          <Button
+            asChild
+            className="w-full border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400"
+          >
+            <Link href={PATHS.TALENT_SUBSCRIBE}>Choose plan</Link>
           </Button>
         )}
       </div>

--- a/components/application-details-modal.tsx
+++ b/components/application-details-modal.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { Calendar, Clock, DollarSign, MapPin, MessageSquare, X } from "lucide-react";
+import { Calendar, Clock, DollarSign, MapPin, MessageSquare } from "lucide-react";
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { SafeImage } from "@/components/ui/safe-image";
+import { PATHS } from "@/lib/constants/routes";
 import { Database } from "@/types/supabase";
 
 // Use generated database types
@@ -39,6 +41,9 @@ interface ApplicationDetailsModalProps {
   booking?: BookingData | null;
 }
 
+const glassCardClass =
+  "panel-frosted min-w-0 border-white/10 bg-[var(--totl-surface-glass-strong)] shadow-none";
+
 export function ApplicationDetailsModal({
   application,
   isOpen,
@@ -50,58 +55,51 @@ export function ApplicationDetailsModal({
   const getStatusColor = (status: Database["public"]["Enums"]["application_status"]) => {
     switch (status) {
       case "accepted":
-        return "bg-green-900/30 text-green-400 border-green-700";
+        return "border-emerald-500/35 bg-emerald-500/15 text-emerald-300";
       case "rejected":
-        return "bg-red-900/30 text-red-400 border-red-700";
+        return "border-red-500/35 bg-red-500/15 text-red-300";
       case "new":
-        return "bg-yellow-900/30 text-yellow-400 border-yellow-700";
+        return "border-amber-500/35 bg-amber-500/15 text-amber-200";
       case "under_review":
-        return "bg-blue-900/30 text-blue-400 border-blue-700";
+        return "border-sky-500/35 bg-sky-500/15 text-sky-200";
       case "shortlisted":
-        return "bg-purple-900/30 text-purple-400 border-purple-700";
+        return "border-violet-500/35 bg-violet-500/15 text-violet-200";
       default:
-        return "bg-gray-900/30 text-gray-400 border-gray-700";
+        return "border-white/15 bg-white/5 text-[var(--oklch-text-secondary)]";
     }
   };
 
   const getCategoryColor = (category: string) => {
     const colors = {
-      "e-commerce": "bg-blue-900/30 text-blue-400 border-blue-700",
-      commercial: "bg-green-900/30 text-green-400 border-green-700",
-      editorial: "bg-purple-900/30 text-purple-400 border-purple-700",
-      runway: "bg-pink-900/30 text-pink-400 border-pink-700",
-      sportswear: "bg-orange-900/30 text-orange-400 border-orange-700",
-      beauty: "bg-yellow-900/30 text-yellow-400 border-yellow-700",
+      "e-commerce": "border-sky-500/35 bg-sky-500/15 text-sky-200",
+      commercial: "border-emerald-500/35 bg-emerald-500/15 text-emerald-200",
+      editorial: "border-violet-500/35 bg-violet-500/15 text-violet-200",
+      runway: "border-pink-500/35 bg-pink-500/15 text-pink-200",
+      sportswear: "border-orange-500/35 bg-orange-500/15 text-orange-200",
+      beauty: "border-amber-500/35 bg-amber-500/15 text-amber-200",
     };
     return (
-      colors[category as keyof typeof colors] || "bg-gray-900/30 text-gray-400 border-gray-700"
+      colors[category as keyof typeof colors] ||
+      "border-white/15 bg-white/5 text-[var(--oklch-text-secondary)]"
     );
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto bg-gray-900 border-gray-800">
-        <DialogHeader>
-          <DialogTitle className="text-white flex items-center justify-between">
-            Application Details
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onClose}
-              className="text-gray-400 hover:text-white hover:bg-gray-800"
-            >
-              <X className="h-4 w-4" />
-            </Button>
+      <DialogContent className="panel-frosted max-h-[90vh] w-[calc(100%-2rem)] max-w-2xl overflow-y-auto border-white/10 bg-[var(--totl-surface-glass-strong)] p-4 text-white sm:w-full sm:p-6">
+        <DialogHeader className="space-y-1 pr-8 text-left">
+          <DialogTitle className="text-lg font-semibold tracking-tight text-white sm:text-xl">
+            Application details
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6">
+        <div className="space-y-4 sm:space-y-6">
           {/* Gig Information */}
-          <Card className="bg-gray-800 border-gray-700">
-            <CardHeader>
-              <div className="flex items-start gap-4">
+          <Card className={glassCardClass}>
+            <CardHeader className="space-y-3">
+              <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start">
                 {application.gigs?.image_url && (
-                  <div className="w-20 h-20 relative rounded-lg overflow-hidden flex-shrink-0">
+                  <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-white/10">
                     <SafeImage
                       src={application.gigs.image_url}
                       alt={application.gigs.title}
@@ -111,17 +109,22 @@ export function ApplicationDetailsModal({
                     />
                   </div>
                 )}
-                <div className="flex-grow">
-                  <CardTitle className="text-white text-xl">{application.gigs?.title}</CardTitle>
-                  <CardDescription className="text-gray-300">
+                <div className="min-w-0 flex-1 space-y-2">
+                  <CardTitle className="text-lg font-semibold text-white sm:text-xl">
+                    {application.gigs?.title}
+                  </CardTitle>
+                  <CardDescription className="text-[var(--oklch-text-secondary)]">
                     {application.gigs?.client_profiles?.company_name || "Private Client"}
                   </CardDescription>
-                  <div className="flex gap-2 mt-2">
-                    <Badge className={getCategoryColor(application.gigs?.category || "General")}>
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    <Badge
+                      variant="outline"
+                      className={getCategoryColor(application.gigs?.category || "General")}
+                    >
                       {application.gigs?.category || "General"}
                     </Badge>
-                    <Badge className={getStatusColor(application.status)}>
-                      {application.status}
+                    <Badge variant="outline" className={getStatusColor(application.status)}>
+                      {application.status.replace(/_/g, " ")}
                     </Badge>
                   </div>
                 </div>
@@ -129,16 +132,18 @@ export function ApplicationDetailsModal({
             </CardHeader>
             <CardContent className="space-y-4">
               {application.gigs?.description && (
-                <p className="text-gray-300">{application.gigs.description}</p>
+                <p className="text-sm leading-relaxed text-[var(--oklch-text-secondary)]">
+                  {application.gigs.description}
+                </p>
               )}
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="flex items-center gap-2 text-gray-300">
-                  <MapPin className="h-4 w-4 text-gray-400" />
-                  <span className="text-sm">{application.gigs?.location}</span>
+              <div className="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2 md:gap-4">
+                <div className="flex min-w-0 items-start gap-2 text-[var(--oklch-text-secondary)]">
+                  <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-[var(--oklch-text-tertiary)]" />
+                  <span className="text-sm leading-snug">{application.gigs?.location}</span>
                 </div>
-                <div className="flex items-center gap-2 text-gray-300">
-                  <DollarSign className="h-4 w-4 text-gray-400" />
+                <div className="flex min-w-0 items-center gap-2 text-[var(--oklch-text-secondary)]">
+                  <DollarSign className="h-4 w-4 flex-shrink-0 text-[var(--oklch-text-tertiary)]" />
                   <span className="text-sm">
                     {booking?.compensation != null
                       ? `$${Number(booking.compensation).toLocaleString()}`
@@ -148,8 +153,8 @@ export function ApplicationDetailsModal({
                   </span>
                 </div>
                 {(booking?.date || application.gigs?.date) && (
-                  <div className="flex items-center gap-2 text-gray-300">
-                    <Calendar className="h-4 w-4 text-gray-400" />
+                  <div className="flex min-w-0 items-center gap-2 text-[var(--oklch-text-secondary)]">
+                    <Calendar className="h-4 w-4 flex-shrink-0 text-[var(--oklch-text-tertiary)]" />
                     <span className="text-sm">
                       {booking?.date
                         ? new Date(booking.date).toLocaleString(undefined, {
@@ -162,50 +167,62 @@ export function ApplicationDetailsModal({
                     </span>
                   </div>
                 )}
-                <div className="flex items-center gap-2 text-gray-300">
-                  <Clock className="h-4 w-4 text-gray-400" />
+                <div className="flex min-w-0 items-center gap-2 text-[var(--oklch-text-secondary)]">
+                  <Clock className="h-4 w-4 flex-shrink-0 text-[var(--oklch-text-tertiary)]" />
                   <span className="text-sm">
                     Applied {new Date(application.created_at).toLocaleDateString()}
                   </span>
                 </div>
               </div>
               {booking?.notes && (
-                <div className="mt-4 p-4 bg-gray-900/50 border border-gray-700 rounded-lg">
-                  <p className="text-sm font-medium text-gray-300 mb-4">Booking Notes</p>
-                  <p className="text-gray-300 text-sm whitespace-pre-wrap">{booking.notes}</p>
+                <div className="rounded-xl border border-white/10 bg-white/[0.04] p-4">
+                  <p className="mb-2 text-sm font-medium text-white">Booking notes</p>
+                  <p className="whitespace-pre-wrap text-sm text-[var(--oklch-text-secondary)]">
+                    {booking.notes}
+                  </p>
                 </div>
               )}
             </CardContent>
           </Card>
 
           {/* Application Details */}
-          <Card className="bg-gray-800 border-gray-700">
+          <Card className={glassCardClass}>
             <CardHeader>
-              <CardTitle className="text-white flex items-center gap-2">
-                <MessageSquare className="h-5 w-5 text-blue-400" />
-                Your Application
+              <CardTitle className="flex items-center gap-2 text-lg font-semibold text-white">
+                <MessageSquare className="h-5 w-5 text-[var(--oklch-accent)]" aria-hidden />
+                Your application
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-300">Application ID</span>
-                  <span className="text-sm text-gray-400 font-mono">{application.id}</span>
+              <div className="space-y-3">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                  <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+                    Application ID
+                  </span>
+                  <span className="break-all text-right font-mono text-xs text-[var(--oklch-text-tertiary)] sm:max-w-[60%] sm:text-sm">
+                    {application.id}
+                  </span>
                 </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-300">Status</span>
-                  <Badge className={getStatusColor(application.status)}>{application.status}</Badge>
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                  <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">Status</span>
+                  <Badge variant="outline" className={getStatusColor(application.status)}>
+                    {application.status.replace(/_/g, " ")}
+                  </Badge>
                 </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-300">Applied Date</span>
-                  <span className="text-sm text-gray-400">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                  <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+                    Applied
+                  </span>
+                  <span className="text-sm text-[var(--oklch-text-tertiary)]">
                     {new Date(application.created_at).toLocaleString()}
                   </span>
                 </div>
                 {application.updated_at !== application.created_at && (
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium text-gray-300">Last Updated</span>
-                    <span className="text-sm text-gray-400">
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                    <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+                      Last updated
+                    </span>
+                    <span className="text-sm text-[var(--oklch-text-tertiary)]">
                       {new Date(application.updated_at).toLocaleString()}
                     </span>
                   </div>
@@ -214,9 +231,11 @@ export function ApplicationDetailsModal({
 
               {application.message && (
                 <div className="space-y-2">
-                  <span className="text-sm font-medium text-gray-300">Cover Letter</span>
-                  <div className="bg-gray-900 border border-gray-700 rounded-lg p-4">
-                    <p className="text-gray-300 text-sm whitespace-pre-wrap">
+                  <span className="text-sm font-medium text-[var(--oklch-text-secondary)]">
+                    Cover letter
+                  </span>
+                  <div className="rounded-xl border border-white/10 bg-white/[0.04] p-4">
+                    <p className="whitespace-pre-wrap text-sm text-[var(--oklch-text-secondary)]">
                       {application.message}
                     </p>
                   </div>
@@ -224,67 +243,116 @@ export function ApplicationDetailsModal({
               )}
 
               {!application.message && (
-                <div className="bg-gray-900 border border-gray-700 rounded-lg p-4 text-center">
-                  <MessageSquare className="h-8 w-8 text-gray-500 mx-auto mb-2" />
-                  <p className="text-gray-400 text-sm">No cover letter provided</p>
+                <div className="rounded-xl border border-white/10 bg-white/[0.04] p-6 text-center">
+                  <MessageSquare
+                    className="mx-auto mb-2 h-8 w-8 text-[var(--oklch-text-tertiary)]"
+                    aria-hidden
+                  />
+                  <p className="text-sm text-[var(--oklch-text-secondary)]">
+                    No cover letter on file for this application.
+                  </p>
+                  <p className="mt-2 text-xs text-[var(--oklch-text-tertiary)]">
+                    Future applications can include a short note from the apply flow.
+                  </p>
                 </div>
               )}
             </CardContent>
           </Card>
 
           {/* Next Steps */}
-          <Card className="bg-gray-800 border-gray-700">
+          <Card className={glassCardClass}>
             <CardHeader>
-              <CardTitle className="text-white">What&apos;s Next?</CardTitle>
+              <CardTitle className="text-lg font-semibold text-white">What happens next</CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="space-y-3">
+              <div className="space-y-4">
                 {(application.status === "new" || application.status === "under_review") && (
                   <div className="flex items-start gap-3">
-                    <div className="w-2 h-2 bg-yellow-400 rounded-full mt-2 flex-shrink-0"></div>
-                    <div>
-                      <p className="text-gray-300 text-sm font-medium">
-                        {application.status === "new" ? "Submitted" : "Under Review"}
+                    <div
+                      className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-amber-400"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 space-y-2">
+                      <p className="text-sm font-medium text-white">
+                        {application.status === "new" ? "Submitted" : "Under review"}
                       </p>
-                      <p className="text-gray-400 text-sm">
-                        The client is reviewing your application. You&apos;ll be notified when they
-                        make a decision.
+                      <p className="text-sm text-[var(--oklch-text-secondary)]">
+                        The client is reviewing your application. We&apos;ll notify you here when the
+                        status changes—no need to follow up unless they reach out.
                       </p>
+                      <Button
+                        asChild
+                        size="sm"
+                        className="mt-1 border-0 bg-gradient-to-r from-amber-500 to-orange-500 text-white hover:from-amber-400 hover:to-orange-400"
+                      >
+                        <Link href={PATHS.GIGS}>Browse open gigs</Link>
+                      </Button>
                     </div>
                   </div>
                 )}
                 {application.status === "shortlisted" && (
                   <div className="flex items-start gap-3">
-                    <div className="w-2 h-2 bg-purple-400 rounded-full mt-2 flex-shrink-0"></div>
-                    <div>
-                      <p className="text-gray-300 text-sm font-medium">Shortlisted!</p>
-                      <p className="text-gray-400 text-sm">
-                        Great news! You&apos;ve been shortlisted. The client will reach out soon with next steps.
+                    <div
+                      className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-violet-400"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 space-y-2">
+                      <p className="text-sm font-medium text-white">Shortlisted</p>
+                      <p className="text-sm text-[var(--oklch-text-secondary)]">
+                        You&apos;re in the running. Watch your inbox and this dashboard—the client may
+                        request more details or next steps soon.
                       </p>
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="border-white/15 bg-white/5 text-white hover:bg-white/10"
+                      >
+                        <Link href={PATHS.TALENT_DASHBOARD}>Back to dashboard</Link>
+                      </Button>
                     </div>
                   </div>
                 )}
                 {application.status === "accepted" && (
                   <div className="flex items-start gap-3">
-                    <div className="w-2 h-2 bg-green-400 rounded-full mt-2 flex-shrink-0"></div>
-                    <div>
-                      <p className="text-gray-300 text-sm font-medium">Congratulations!</p>
-                      <p className="text-gray-400 text-sm">
-                        Your application has been accepted. The client will contact you with next
-                        steps.
+                    <div
+                      className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-emerald-400"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 space-y-2">
+                      <p className="text-sm font-medium text-white">Accepted</p>
+                      <p className="text-sm text-[var(--oklch-text-secondary)]">
+                        Confirmed details and booking notes (if any) appear above. Check your
+                        dashboard for scheduling and follow up with the client through the agreed
+                        channel.
                       </p>
+                      <Button
+                        asChild
+                        size="sm"
+                        className="border-0 bg-gradient-to-r from-emerald-500 to-teal-600 text-white hover:from-emerald-400 hover:to-teal-500"
+                      >
+                        <Link href={PATHS.TALENT_DASHBOARD}>Open dashboard</Link>
+                      </Button>
                     </div>
                   </div>
                 )}
                 {application.status === "rejected" && (
                   <div className="flex items-start gap-3">
-                    <div className="w-2 h-2 bg-red-400 rounded-full mt-2 flex-shrink-0"></div>
-                    <div>
-                      <p className="text-gray-300 text-sm font-medium">Application Not Selected</p>
-                      <p className="text-gray-400 text-sm">
-                        Unfortunately, this application wasn&apos;t selected. Keep applying to other
-                        opportunities!
+                    <div className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-red-400" aria-hidden />
+                    <div className="min-w-0 space-y-2">
+                      <p className="text-sm font-medium text-white">Not selected</p>
+                      <p className="text-sm text-[var(--oklch-text-secondary)]">
+                        This role went another direction. Your profile stays visible for future
+                        opportunities—keep momentum with roles that fit you.
                       </p>
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="border-white/15 bg-white/5 text-white hover:bg-white/10"
+                      >
+                        <Link href={PATHS.GIGS}>Find your next gig</Link>
+                      </Button>
                     </div>
                   </div>
                 )}

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -50,14 +50,14 @@ export function getSubscriptionStatusText(status: SubscriptionStatus): string {
 export function getSubscriptionStatusColor(status: SubscriptionStatus): string {
   switch (status) {
     case 'active':
-      return 'text-green-600';
+      return 'border-emerald-500/35 bg-emerald-500/15 text-emerald-200';
     case 'past_due':
-      return 'text-yellow-600';
+      return 'border-amber-500/35 bg-amber-500/15 text-amber-200';
     case 'canceled':
     case 'none':
-      return 'text-gray-600';
+      return 'border-white/15 bg-white/5 text-[var(--oklch-text-secondary)]';
     default:
-      return 'text-gray-600';
+      return 'border-white/15 bg-white/5 text-[var(--oklch-text-secondary)]';
   }
 }
 


### PR DESCRIPTION
What broke

Talent **settings**, **application details modal**, and **talent billing** still looked like older **gray slabs** instead of the **frosted / OKLCH** system used elsewhere. The modal duplicated the **close** control, and dense rows (for example **application ID** and settings footers) were awkward on **narrow viewports**.

Why it broke

Those files were not fully migrated when **`panel-frosted`**, **`--totl-surface-glass-strong`**, and **`--oklch-text-*`** became the standard for authenticated surfaces.

What we changed

- **`components/application-details-modal.tsx`:** Glass dialog and inner cards; removed the extra header close; clearer status messaging and **single CTAs** via **`PATHS`**.
- **`app/settings/sections/account-settings.tsx`**, **`basic-info.tsx`**, **`subscription-section.tsx`**, **`talent-details.tsx`**, **`career-builder-section.tsx`:** Glass cards and inputs, cohesive primary buttons, improved alerts; subscription links use **`PATHS` / `PREFIXES`**.
- **`app/talent/settings/billing/billing-settings.tsx`:** Glass/OKLCH pass consistent with subscription.
- **`app/talent/profile/loading.tsx`:** Frosted loading shell.
- **`lib/subscription.ts`:** **`getSubscriptionStatusColor`** returns dark-glass-friendly badge classes.
- **`MVP_STATUS_NOTION.md`:** Recorded this batch and next P0/P1 steps.

**Branch scope:** This PR merges all of **`develop`** into **`main`**; `main` is many commits behind. The latest commit is **`e8e5372`** (`fix(ui): premium glass pass on settings modal and billing`). Earlier commits on `develop` (admin, gigs, auth, CI, etc.) are included in the same merge.

How we proved it

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass
- `npm run lint` — pass

Pre-commit (on `git commit`) also ran guards and **`npm run build`** — pass.

Manual smoke on `/settings`, talent dashboard modal, and `/talent/settings/billing` was **not** run in this session.

Docs updated: yes

- `MVP_STATUS_NOTION.md`

Risk + rollback

**Risk level:** Low (mostly Tailwind/className and copy; subscription helper only changes CSS class strings returned for badges).

**Rollback plan:** Revert **`e8e5372`** for the UI slice, or revert the merge commit on **`main`** if problems appear after this PR lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily styling/className + copy updates, plus a small tweak to `getSubscriptionStatusColor` output used for badge styling.
> 
> **Overview**
> Updates authenticated talent surfaces to the premium *glass/OKLCH* design language: settings sections, subscription/career builder panels, talent billing page, talent profile loading skeleton, and the application details modal.
> 
> The modal and settings flows also get UX polish (mobile-safe layout tweaks, simplified/consistent copy, status-aware “next steps” CTAs using `PATHS`/`PREFIXES`, and removal of a duplicate modal close control), and subscription status badge styling is centralized via updated `getSubscriptionStatusColor` classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e5372ced7f12e44268c916b274ae53cfad1bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->