### PR TITLE
fix(auth): reliable Career Builder apply session convergence

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -11,17 +11,18 @@
 ## 🚀 **Latest: Career Builder invite — server session convergence (April 13, 2026)**
 
 **AUTH / CAREER BUILDER** — April 13, 2026
-- ✅ **`lib/auth/wait-for-server-session-ready.ts`:** Shared client probe for **`GET /api/auth/session-ready`** with bounded exponential backoff + jitter (mobile / Safari cookie visibility).
-- ✅ **`app/auth/callback/page.tsx`:** Longer session-ready wait + extended **`getBootStateRedirect`** polling before leaving callback.
-- ✅ **`app/client/apply/page.tsx`:** Submit path waits for server-visible session (~45s cap) with **Finishing sign-in…** button copy; status check uses one bounded wait then fetch retries (avoids long nested loops); hard-fail toast gives refresh + retry guidance (replaces misleading **Still signing you in** on first submit).
+- ✅ **`lib/auth/wait-for-server-session-ready.ts`:** Shared client probe for **`GET /api/auth/session-ready`** with bounded exponential backoff + jitter (mobile / Safari cookie visibility); **per-fetch AbortController** (~12s) so a stalled request cannot hang a single attempt; returns **structured `terminal`** (`not_ready` | `server_error` | `fetch_timeout` | `network`) for UX + logs.
+- ✅ **`app/api/auth/session-ready/route.ts`:** JSON **`reason`** codes (`no_session`, `auth_error`, `server_exception`) with **`logger.warn`** on failure paths (no user PII).
+- ✅ **`app/auth/callback/page.tsx`:** Longer session-ready wait + extended **`getBootStateRedirect`** polling before leaving callback; callback hard-fail copy varies by **`terminal`**.
+- ✅ **`app/client/apply/page.tsx`:** Submit path waits for server-visible session (~45s cap) with **Finishing sign-in…** button copy; status check uses one bounded wait then fetch retries (avoids long nested loops); submit/status toasts and banners vary by **`terminal`** when the probe exhausts.
 - ✅ **`tests/auth/invite-client-apply-flow.spec.ts`:** Success URL assertion timeout increased for slow cookie sync / CI.
-- ✅ **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`:** Invite → apply submit race documented with current mitigation.
+- ✅ **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`:** Invite → apply submit race + session-ready diagnostics documented.
 
-**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 13, 2026.
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 13, 2026 (session-ready hardening pass).
 
 **Next (P0):** Merge **develop → main** via PR; smoke **invite → `/auth/callback` → `/client/apply` → submit → `/client/apply/success`** on staging (mobile Safari if available).
 
-**Next (P1):** Optional **`fetch` timeout** (AbortController) on the session-ready probe to bound rare hung requests.
+**Next (P1):** Optional **metrics or Sentry breadcrumbs** on `session-ready` terminal counts in production (if noise is acceptable).
 
 ---
 

--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,23 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Career Builder invite — server session convergence (April 13, 2026)**
+
+**AUTH / CAREER BUILDER** — April 13, 2026
+- ✅ **`lib/auth/wait-for-server-session-ready.ts`:** Shared client probe for **`GET /api/auth/session-ready`** with bounded exponential backoff + jitter (mobile / Safari cookie visibility).
+- ✅ **`app/auth/callback/page.tsx`:** Longer session-ready wait + extended **`getBootStateRedirect`** polling before leaving callback.
+- ✅ **`app/client/apply/page.tsx`:** Submit path waits for server-visible session (~45s cap) with **Finishing sign-in…** button copy; status check uses one bounded wait then fetch retries (avoids long nested loops); hard-fail toast gives refresh + retry guidance (replaces misleading **Still signing you in** on first submit).
+- ✅ **`tests/auth/invite-client-apply-flow.spec.ts`:** Success URL assertion timeout increased for slow cookie sync / CI.
+- ✅ **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`:** Invite → apply submit race documented with current mitigation.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 13, 2026.
+
+**Next (P0):** Merge **develop → main** via PR; smoke **invite → `/auth/callback` → `/client/apply` → submit → `/client/apply/success`** on staging (mobile Safari if available).
+
+**Next (P1):** Optional **`fetch` timeout** (AbortController) on the session-ready probe to bound rare hung requests.
+
+---
+
 ## 🚀 **Latest: Bugbot triage — portfolio `exists()`, talent empty state, `PageShell` padding (April 12, 2026)**
 
 **QUALITY / UX** — April 12, 2026

--- a/app/api/auth/session-ready/route.ts
+++ b/app/api/auth/session-ready/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
+import { logger } from "@/lib/utils/logger";
 
 export async function GET() {
   try {
@@ -10,15 +11,19 @@ export async function GET() {
     } = await supabase.auth.getUser();
 
     if (error) {
-      return NextResponse.json({ ready: false }, { status: 500 });
+      logger.warn("[session-ready] getUser error", { message: error.message });
+      return NextResponse.json({ ready: false, reason: "auth_error" }, { status: 500 });
     }
 
     if (!user) {
-      return NextResponse.json({ ready: false }, { status: 401 });
+      return NextResponse.json({ ready: false, reason: "no_session" }, { status: 401 });
     }
 
     return NextResponse.json({ ready: true }, { status: 200 });
-  } catch {
-    return NextResponse.json({ ready: false }, { status: 500 });
+  } catch (unexpected) {
+    logger.warn("[session-ready] handler exception", {
+      message: unexpected instanceof Error ? unexpected.message : "unknown",
+    });
+    return NextResponse.json({ ready: false, reason: "server_exception" }, { status: 500 });
   }
 }

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -131,14 +131,18 @@ function AuthCallbackGate() {
         window.history.replaceState({}, "", `${PATHS.AUTH_CALLBACK}?returnUrl=${encodeURIComponent(safeReturn)}`);
 
         // Ensure server-side auth sees the cookie-backed session before leaving callback.
-        const serverSessionReady = await waitForServerSessionReady({
+        const sessionProbe = await waitForServerSessionReady({
           maxWaitMs: CALLBACK_SESSION_WAIT_MS,
         });
-        if (!serverSessionReady) {
+        if (!sessionProbe.ok) {
           logger.warn("[auth/callback] server session not ready after callback exchange", {
             hasCode: Boolean(code),
             hasTokenHash: Boolean(tokenHash),
             hasOtpType: Boolean(otpType),
+            terminal: sessionProbe.terminal,
+            attempts: sessionProbe.attempts,
+            lastHttpStatus: sessionProbe.lastHttpStatus,
+            lastBodyReason: sessionProbe.lastBodyReason,
           });
         }
 
@@ -157,10 +161,14 @@ function AuthCallbackGate() {
         }
 
         if (cancelled) return;
-        if (!resolvedTarget && !serverSessionReady) {
-          throw new Error(
-            "We couldn't finalize your sign-in session yet. Please reopen the invite link and try again."
-          );
+        if (!resolvedTarget && !sessionProbe.ok) {
+          const message =
+            sessionProbe.terminal === "server_error"
+              ? "Our servers could not verify your account yet. Wait a minute, then reopen your invite link or try signing in from the login page."
+              : sessionProbe.terminal === "fetch_timeout" || sessionProbe.terminal === "network"
+                ? "The connection timed out while finishing sign-in. Check your network, then reopen the invite link."
+                : "We couldn't finalize your sign-in session yet. Please reopen the invite link and try again.";
+          throw new Error(message);
         }
         const target = resolvedTarget ?? safeReturn;
         router.replace(target);

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -13,6 +13,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { getBootStateRedirect } from "@/lib/actions/boot-actions";
+import { sleepBootRetryDelayMs, waitForServerSessionReady } from "@/lib/auth/wait-for-server-session-ready";
 import { PATHS } from "@/lib/constants/routes";
 import { useSupabase } from "@/lib/hooks/use-supabase";
 import { logger } from "@/lib/utils/logger";
@@ -22,29 +23,8 @@ type GateState =
   | { kind: "checking"; message: string }
   | { kind: "failed"; message: string };
 
-async function waitForServerSessionReady(maxAttempts = 6): Promise<boolean> {
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    try {
-      const response = await fetch("/api/auth/session-ready", {
-        method: "GET",
-        cache: "no-store",
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        return true;
-      }
-    } catch {
-      // Ignore probe failures and retry with backoff.
-    }
-
-    if (attempt < maxAttempts - 1) {
-      await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
-    }
-  }
-
-  return false;
-}
+const CALLBACK_SESSION_WAIT_MS = 38_000;
+const CALLBACK_BOOT_POLL_BUDGET_MS = 32_000;
 
 const isSupportedOtpType = (
   value: string | null | undefined
@@ -151,7 +131,9 @@ function AuthCallbackGate() {
         window.history.replaceState({}, "", `${PATHS.AUTH_CALLBACK}?returnUrl=${encodeURIComponent(safeReturn)}`);
 
         // Ensure server-side auth sees the cookie-backed session before leaving callback.
-        const serverSessionReady = await waitForServerSessionReady();
+        const serverSessionReady = await waitForServerSessionReady({
+          maxWaitMs: CALLBACK_SESSION_WAIT_MS,
+        });
         if (!serverSessionReady) {
           logger.warn("[auth/callback] server session not ready after callback exchange", {
             hasCode: Boolean(code),
@@ -160,17 +142,18 @@ function AuthCallbackGate() {
           });
         }
 
-        // Cookie sync to server can be briefly delayed after setSession/verifyOtp.
+        // Cookie sync + profile bootstrap can lag behind the browser session (mobile/Safari).
         let resolvedTarget: string | null = null;
-        for (let attempt = 0; attempt < 5; attempt += 1) {
+        const bootStarted = Date.now();
+        let bootAttempt = 0;
+        while (Date.now() - bootStarted < CALLBACK_BOOT_POLL_BUDGET_MS) {
           const result = await getBootStateRedirect({ postAuth: true, returnUrlRaw });
           if (result.redirectTo) {
             resolvedTarget = result.redirectTo;
             break;
           }
-          if (attempt < 4) {
-            await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
-          }
+          await sleepBootRetryDelayMs(bootAttempt);
+          bootAttempt += 1;
         }
 
         if (cancelled) return;

--- a/app/client/apply/page.tsx
+++ b/app/client/apply/page.tsx
@@ -1,4 +1,4 @@
- "use client";
+"use client";
 
 import { ArrowLeft } from "lucide-react";
 import Image from "next/image";
@@ -22,31 +22,12 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { submitClientApplication } from "@/lib/actions/client-actions";
+import { waitForServerSessionReady } from "@/lib/auth/wait-for-server-session-ready";
 import { logger } from "@/lib/utils/logger";
 
-async function waitForServerSessionReady(maxAttempts = 6): Promise<boolean> {
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    try {
-      const response = await fetch("/api/auth/session-ready", {
-        method: "GET",
-        cache: "no-store",
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        return true;
-      }
-    } catch {
-      // Ignore probe errors and retry with short backoff.
-    }
-
-    if (attempt < maxAttempts - 1) {
-      await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
-    }
-  }
-
-  return false;
-}
+const APPLY_SUBMIT_SESSION_WAIT_MS = 45_000;
+/** One bounded wait after navigation before hitting status API (avoids multi-minute nested loops). */
+const APPLY_STATUS_INITIAL_WAIT_MS = 28_000;
 
 export default function ClientApplicationPage() {
   const [formData, setFormData] = useState({
@@ -61,6 +42,7 @@ export default function ClientApplicationPage() {
     website: "",
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitBusyLabel, setSubmitBusyLabel] = useState("Submitting...");
   const [hasStartedEditing, setHasStartedEditing] = useState(false);
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const router = useRouter();
@@ -112,18 +94,25 @@ export default function ClientApplicationPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
+    setSubmitBusyLabel("Finishing sign-in…");
 
     try {
-      const serverSessionReady = await waitForServerSessionReady();
+      const serverSessionReady = await waitForServerSessionReady({
+        maxWaitMs: APPLY_SUBMIT_SESSION_WAIT_MS,
+      });
       if (!serverSessionReady) {
         toast({
-          title: "Still signing you in",
-          description: "Your session is still finishing. Please wait a moment and try again.",
+          title: "Could not confirm your session yet",
+          description:
+            "Your browser signed you in, but our servers did not see the session in time. Refresh this page, then tap Submit again. If it keeps happening, wait one minute and retry.",
           variant: "destructive",
         });
         setIsSubmitting(false);
+        setSubmitBusyLabel("Submitting...");
         return;
       }
+
+      setSubmitBusyLabel("Submitting...");
 
       const result = await submitClientApplication({
         firstName: formData.firstName,
@@ -144,6 +133,7 @@ export default function ClientApplicationPage() {
           variant: "destructive",
         });
         setIsSubmitting(false);
+        setSubmitBusyLabel("Submitting...");
         return;
       }
 
@@ -165,6 +155,7 @@ export default function ClientApplicationPage() {
         variant: "destructive",
       });
       setIsSubmitting(false);
+      setSubmitBusyLabel("Submitting...");
     }
   };
 
@@ -181,27 +172,28 @@ export default function ClientApplicationPage() {
     const checkStatus = async () => {
       setIsCheckingStatus(true);
       try {
+        setStatusMessage("Finishing sign-in… Checking whether you already have an application on file.");
+        const serverSessionReady = await waitForServerSessionReady({
+          maxWaitMs: APPLY_STATUS_INITIAL_WAIT_MS,
+        });
+        if (!serverSessionReady) {
+          setStatusMessage(
+            "Still finishing sign-in. You can continue filling out the form — we will retry status in the background."
+          );
+        }
+
         let response: Response | null = null;
-
-        for (let attempt = 0; attempt < 6; attempt += 1) {
-          const serverSessionReady = await waitForServerSessionReady();
-          if (!serverSessionReady) {
-            setStatusMessage("Finalizing your sign-in. Checking application status...");
-            continue;
-          }
-
+        for (let attempt = 0; attempt < 8; attempt += 1) {
           response = await fetch(`/api/client-applications/status`, { signal: controller.signal });
 
-          // Invite/callback flows can briefly race server cookie visibility even after
-          // the browser session exists. Retry auth failures before surfacing an error.
           if (response.ok) {
             break;
           }
 
           if (response.status === 401 || response.status === 403) {
-            setStatusMessage("Finalizing your sign-in. Checking application status...");
-            if (attempt < 5) {
-              await new Promise((resolve) => setTimeout(resolve, 200 * (attempt + 1)));
+            setStatusMessage("Finishing sign-in… Checking application status.");
+            if (attempt < 7) {
+              await new Promise((resolve) => setTimeout(resolve, 450 * (attempt + 1)));
               continue;
             }
           }
@@ -496,7 +488,7 @@ export default function ClientApplicationPage() {
                         applicationStatus?.status === "pending"
                       }
                     >
-                      {isSubmitting ? "Submitting..." : "Submit Application"}
+                      {isSubmitting ? submitBusyLabel : "Submit Application"}
                     </Button>
                     <p className="text-sm text-[var(--oklch-text-muted)] mt-4 text-left">
                       By submitting this form, you agree to our{" "}

--- a/app/client/apply/page.tsx
+++ b/app/client/apply/page.tsx
@@ -22,12 +22,46 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
 import { submitClientApplication } from "@/lib/actions/client-actions";
-import { waitForServerSessionReady } from "@/lib/auth/wait-for-server-session-ready";
+import {
+  type WaitForServerSessionReadyResult,
+  waitForServerSessionReady,
+} from "@/lib/auth/wait-for-server-session-ready";
 import { logger } from "@/lib/utils/logger";
 
 const APPLY_SUBMIT_SESSION_WAIT_MS = 45_000;
 /** One bounded wait after navigation before hitting status API (avoids multi-minute nested loops). */
 const APPLY_STATUS_INITIAL_WAIT_MS = 28_000;
+
+function sessionProbeFailureToast(
+  probe: Extract<WaitForServerSessionReadyResult, { ok: false }>
+): { title: string; description: string } {
+  switch (probe.terminal) {
+    case "server_error":
+      return {
+        title: "Could not verify your session on our servers",
+        description:
+          "The sign-in check failed with a server error. Wait a minute, refresh this page, then tap Submit again. If it keeps failing, contact support with the approximate time you tried.",
+      };
+    case "fetch_timeout":
+      return {
+        title: "Sign-in check timed out",
+        description:
+          "Confirming your session took too long to respond. Check your connection, refresh this page, then tap Submit again.",
+      };
+    case "network":
+      return {
+        title: "Connection problem during sign-in check",
+        description:
+          "We could not reach the server to confirm your session. Check your network, refresh this page, then try again.",
+      };
+    case "not_ready":
+      return {
+        title: "Could not confirm your session yet",
+        description:
+          "Your browser signed you in, but our servers did not see the session in time. Refresh this page, then tap Submit again. If it keeps happening, wait one minute and retry.",
+      };
+  }
+}
 
 export default function ClientApplicationPage() {
   const [formData, setFormData] = useState({
@@ -97,14 +131,20 @@ export default function ClientApplicationPage() {
     setSubmitBusyLabel("Finishing sign-in…");
 
     try {
-      const serverSessionReady = await waitForServerSessionReady({
+      const sessionProbe = await waitForServerSessionReady({
         maxWaitMs: APPLY_SUBMIT_SESSION_WAIT_MS,
       });
-      if (!serverSessionReady) {
+      if (!sessionProbe.ok) {
+        logger.warn("[client/apply] session-ready probe exhausted (submit)", {
+          terminal: sessionProbe.terminal,
+          attempts: sessionProbe.attempts,
+          lastHttpStatus: sessionProbe.lastHttpStatus,
+          lastBodyReason: sessionProbe.lastBodyReason,
+        });
+        const { title, description } = sessionProbeFailureToast(sessionProbe);
         toast({
-          title: "Could not confirm your session yet",
-          description:
-            "Your browser signed you in, but our servers did not see the session in time. Refresh this page, then tap Submit again. If it keeps happening, wait one minute and retry.",
+          title,
+          description,
           variant: "destructive",
         });
         setIsSubmitting(false);
@@ -173,13 +213,29 @@ export default function ClientApplicationPage() {
       setIsCheckingStatus(true);
       try {
         setStatusMessage("Finishing sign-in… Checking whether you already have an application on file.");
-        const serverSessionReady = await waitForServerSessionReady({
+        const sessionProbe = await waitForServerSessionReady({
           maxWaitMs: APPLY_STATUS_INITIAL_WAIT_MS,
         });
-        if (!serverSessionReady) {
-          setStatusMessage(
-            "Still finishing sign-in. You can continue filling out the form — we will retry status in the background."
-          );
+        if (!sessionProbe.ok) {
+          logger.warn("[client/apply] session-ready probe exhausted (status prefetch)", {
+            terminal: sessionProbe.terminal,
+            attempts: sessionProbe.attempts,
+            lastHttpStatus: sessionProbe.lastHttpStatus,
+            lastBodyReason: sessionProbe.lastBodyReason,
+          });
+          if (sessionProbe.terminal === "server_error") {
+            setStatusMessage(
+              "Our servers could not verify your session yet. You can still fill out the form; refresh the page if this message persists."
+            );
+          } else if (sessionProbe.terminal === "fetch_timeout" || sessionProbe.terminal === "network") {
+            setStatusMessage(
+              "The sign-in check timed out or hit a connection issue. You can keep filling out the form; refresh if your application status does not load."
+            );
+          } else {
+            setStatusMessage(
+              "Still finishing sign-in. You can continue filling out the form — we will retry status in the background."
+            );
+          }
         }
 
         let response: Response | null = null;

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 12, 2026 (Bugbot triage: portfolio `exists()` UX, talent empty-state string, `PageShell` padding — see `MVP_STATUS_NOTION.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`; prior: gig marketing paywall, admin gig delete / bookings RLS, `docs/runbooks/production-gig-cleanup.md`)
+**Last Updated:** April 13, 2026 (Career Builder invite session-ready hardening: `lib/auth/wait-for-server-session-ready.ts`, callback + `/client/apply` — see `MVP_STATUS_NOTION.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`; prior: Bugbot triage April 12, gig marketing paywall, admin gig delete / bookings RLS)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 13, 2026 (Career Builder invite session-ready hardening: `lib/auth/wait-for-server-session-ready.ts`, callback + `/client/apply` — see `MVP_STATUS_NOTION.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`; prior: Bugbot triage April 12, gig marketing paywall, admin gig delete / bookings RLS)
+**Last Updated:** April 13, 2026 (session-ready: per-fetch timeout, JSON `reason` + `logger.warn` on route, structured `terminal` on client — see `MVP_STATUS_NOTION.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`; prior: Bugbot triage April 12, gig marketing paywall, admin gig delete / bookings RLS)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -309,7 +309,8 @@ npm run build
   - **Root Cause:** Callback can establish browser session before server-side cookie visibility fully converges; server action `submitClientApplication()` calls `auth.getUser()` and may read `null` during this race.
   - **Fix:** In callback gate, wait for server session readiness before redirecting:
     - add `GET /api/auth/session-ready` that validates server `auth.getUser()`
-    - retry probe with short backoff before leaving `/auth/callback`
+    - retry the probe with **bounded** exponential backoff + jitter (~tens of seconds cap) before leaving `/auth/callback` (mobile Safari often needs more than a few seconds)
+    - on `/client/apply`, use the same probe with a similar cap **before** `submitClientApplication()`; show “Finishing sign-in…” instead of failing on the first 401 from the probe
   - **Fix:** Add structured diagnostics in `submitClientApplication()` with `traceId` across auth lookup, duplicate check, insert, and email side-effects to isolate branch failures quickly.
   - **Prevention:** For invite-linked auth flows, verify both browser and server session convergence before navigating users into server-action submit pages.
 - **Career Builder hard delete fails with FK error (`SQLSTATE 23503`, `client_applications_user_id_fkey`):**

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -311,6 +311,9 @@ npm run build
     - add `GET /api/auth/session-ready` that validates server `auth.getUser()`
     - retry the probe with **bounded** exponential backoff + jitter (~tens of seconds cap) before leaving `/auth/callback` (mobile Safari often needs more than a few seconds)
     - on `/client/apply`, use the same probe with a similar cap **before** `submitClientApplication()`; show “Finishing sign-in…” instead of failing on the first 401 from the probe
+    - each probe `fetch` uses an **AbortController** per attempt (~12s default) so a stalled connection cannot hang until the overall budget elapses
+    - `GET /api/auth/session-ready` returns JSON **`reason`**: `no_session` (401), `auth_error` / `server_exception` (500) for client-side distinction; **`logger.warn`** on server for auth/exception paths (no user PII)
+    - `waitForServerSessionReady` returns a **structured result** (`terminal`: `not_ready` | `server_error` | `fetch_timeout` | `network`) for apply/callback copy + **`logger.warn`** fields on exhaustion
   - **Fix:** Add structured diagnostics in `submitClientApplication()` with `traceId` across auth lookup, duplicate check, insert, and email side-effects to isolate branch failures quickly.
   - **Prevention:** For invite-linked auth flows, verify both browser and server session convergence before navigating users into server-action submit pages.
 - **Career Builder hard delete fails with FK error (`SQLSTATE 23503`, `client_applications_user_id_fkey`):**

--- a/lib/auth/wait-for-server-session-ready.ts
+++ b/lib/auth/wait-for-server-session-ready.ts
@@ -10,7 +10,26 @@ export type WaitForServerSessionReadyOptions = {
   initialBackoffMs?: number;
   /** Maximum delay (ms) between retries. */
   maxBackoffMs?: number;
+  /** Max time (ms) for a single fetch; avoids hanging on stalled connections. */
+  perFetchTimeoutMs?: number;
 };
+
+/** Last outcome when `ok` is false — distinguishes cookie lag vs server vs transport. */
+export type WaitForServerSessionTerminal =
+  | "not_ready"
+  | "server_error"
+  | "fetch_timeout"
+  | "network";
+
+export type WaitForServerSessionReadyResult =
+  | { ok: true; attempts: number }
+  | {
+      ok: false;
+      terminal: WaitForServerSessionTerminal;
+      attempts: number;
+      lastHttpStatus?: number;
+      lastBodyReason?: string;
+    };
 
 function nextBackoffMs(
   attempt: number,
@@ -22,30 +41,100 @@ function nextBackoffMs(
   return exp + jitter;
 }
 
+type ProbeOnceResult =
+  | { kind: "ok" }
+  | { kind: "not_ready"; lastHttpStatus: 401; lastBodyReason?: string }
+  | { kind: "server_fail"; lastHttpStatus: number; lastBodyReason?: string }
+  | { kind: "fetch_timeout" }
+  | { kind: "network" };
+
+async function probeSessionReadyOnce(perFetchTimeoutMs: number): Promise<ProbeOnceResult> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), perFetchTimeoutMs);
+  try {
+    const response = await fetch("/api/auth/session-ready", {
+      method: "GET",
+      cache: "no-store",
+      credentials: "include",
+      signal: ac.signal,
+    });
+    clearTimeout(timer);
+
+    if (response.ok) {
+      return { kind: "ok" };
+    }
+
+    let lastBodyReason: string | undefined;
+    try {
+      const j = (await response.json()) as { reason?: string };
+      if (typeof j.reason === "string") lastBodyReason = j.reason;
+    } catch {
+      // Non-JSON error body — ignore.
+    }
+
+    if (response.status === 401) {
+      return { kind: "not_ready", lastHttpStatus: 401, lastBodyReason };
+    }
+    return { kind: "server_fail", lastHttpStatus: response.status, lastBodyReason };
+  } catch (e) {
+    clearTimeout(timer);
+    if (e instanceof DOMException && e.name === "AbortError") {
+      return { kind: "fetch_timeout" };
+    }
+    return { kind: "network" };
+  }
+}
+
+type FailedProbe = Exclude<ProbeOnceResult, { kind: "ok" }>;
+
+function terminalFromLastProbe(last: FailedProbe): Omit<
+  Extract<WaitForServerSessionReadyResult, { ok: false }>,
+  "ok" | "attempts"
+> {
+  switch (last.kind) {
+    case "not_ready":
+      return {
+        terminal: "not_ready",
+        lastHttpStatus: last.lastHttpStatus,
+        lastBodyReason: last.lastBodyReason,
+      };
+    case "server_fail":
+      return {
+        terminal: "server_error",
+        lastHttpStatus: last.lastHttpStatus,
+        lastBodyReason: last.lastBodyReason,
+      };
+    case "fetch_timeout":
+      return { terminal: "fetch_timeout" };
+    case "network":
+      return { terminal: "network" };
+    default: {
+      const _x: never = last;
+      return _x;
+    }
+  }
+}
+
 export async function waitForServerSessionReady(
   options?: WaitForServerSessionReadyOptions
-): Promise<boolean> {
+): Promise<WaitForServerSessionReadyResult> {
   const maxWaitMs = options?.maxWaitMs ?? 40_000;
   const initialBackoffMs = options?.initialBackoffMs ?? 280;
   const maxBackoffMs = options?.maxBackoffMs ?? 2_600;
+  const perFetchTimeoutMs = options?.perFetchTimeoutMs ?? 12_000;
 
   const started = Date.now();
   let attempt = 0;
+  let lastFailedProbe: FailedProbe = { kind: "not_ready", lastHttpStatus: 401 };
 
   while (Date.now() - started < maxWaitMs) {
-    try {
-      const response = await fetch("/api/auth/session-ready", {
-        method: "GET",
-        cache: "no-store",
-        credentials: "include",
-      });
+    const probe = await probeSessionReadyOnce(perFetchTimeoutMs);
 
-      if (response.ok) {
-        return true;
-      }
-    } catch {
-      // Network / abort — treat as not ready and retry.
+    if (probe.kind === "ok") {
+      return { ok: true, attempts: attempt + 1 };
     }
+
+    lastFailedProbe = probe;
 
     const wait = nextBackoffMs(attempt, initialBackoffMs, maxBackoffMs);
     const elapsed = Date.now() - started;
@@ -57,7 +146,14 @@ export async function waitForServerSessionReady(
     attempt += 1;
   }
 
-  return false;
+  const { terminal, lastHttpStatus, lastBodyReason } = terminalFromLastProbe(lastFailedProbe);
+  return {
+    ok: false,
+    terminal,
+    attempts: attempt + 1,
+    lastHttpStatus,
+    lastBodyReason,
+  };
 }
 
 /** Used by auth callback boot polling — same backoff shape as session-ready. */

--- a/lib/auth/wait-for-server-session-ready.ts
+++ b/lib/auth/wait-for-server-session-ready.ts
@@ -1,0 +1,71 @@
+/**
+ * Client-only: probes until the Next.js route handler sees the same session as the browser.
+ * Invite / OTP flows often need extra time for cookies to sync (notably mobile Safari).
+ */
+
+export type WaitForServerSessionReadyOptions = {
+  /** Hard cap on total wait time (ms). */
+  maxWaitMs?: number;
+  /** Base delay (ms) before the first retry; grows exponentially with a cap. */
+  initialBackoffMs?: number;
+  /** Maximum delay (ms) between retries. */
+  maxBackoffMs?: number;
+};
+
+function nextBackoffMs(
+  attempt: number,
+  initialBackoffMs: number,
+  maxBackoffMs: number
+): number {
+  const exp = Math.min(maxBackoffMs, initialBackoffMs * 2 ** Math.min(attempt, 8));
+  const jitter = Math.floor(Math.random() * 150);
+  return exp + jitter;
+}
+
+export async function waitForServerSessionReady(
+  options?: WaitForServerSessionReadyOptions
+): Promise<boolean> {
+  const maxWaitMs = options?.maxWaitMs ?? 40_000;
+  const initialBackoffMs = options?.initialBackoffMs ?? 280;
+  const maxBackoffMs = options?.maxBackoffMs ?? 2_600;
+
+  const started = Date.now();
+  let attempt = 0;
+
+  while (Date.now() - started < maxWaitMs) {
+    try {
+      const response = await fetch("/api/auth/session-ready", {
+        method: "GET",
+        cache: "no-store",
+        credentials: "include",
+      });
+
+      if (response.ok) {
+        return true;
+      }
+    } catch {
+      // Network / abort — treat as not ready and retry.
+    }
+
+    const wait = nextBackoffMs(attempt, initialBackoffMs, maxBackoffMs);
+    const elapsed = Date.now() - started;
+    const remaining = maxWaitMs - elapsed;
+    if (remaining <= 0) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(wait, remaining)));
+    attempt += 1;
+  }
+
+  return false;
+}
+
+/** Used by auth callback boot polling — same backoff shape as session-ready. */
+export async function sleepBootRetryDelayMs(
+  attempt: number,
+  initialBackoffMs = 280,
+  maxBackoffMs = 2_600
+): Promise<void> {
+  const ms = nextBackoffMs(attempt, initialBackoffMs, maxBackoffMs);
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/auth/invite-client-apply-flow.spec.ts
+++ b/tests/auth/invite-client-apply-flow.spec.ts
@@ -62,7 +62,8 @@ test.describe("Invite to client apply flow", () => {
     );
 
     await page.getByRole("button", { name: "Submit Application" }).click();
-    await expect(page).toHaveURL(/\/client\/apply\/success/, { timeout: 30_000 });
+    // Submit waits for server-visible session (cookie sync); allow slow mobile / CI.
+    await expect(page).toHaveURL(/\/client\/apply\/success/, { timeout: 90_000 });
     await expect(page.getByRole("heading", { name: /application submitted successfully/i })).toBeVisible({
       timeout: 20_000,
     });


### PR DESCRIPTION
What broke

Career Builder users invited via Supabase could reach `/client/apply` with a browser session while the Next.js server still returned 401 from `/api/auth/session-ready` for longer than the old probe (~3s). Submitting the application immediately showed a destructive "Still signing you in" toast and blocked submission even though the session was still converging (worse on mobile Safari).

Why it broke

Client auth state and HttpOnly cookie visibility on the server can lag after `exchangeCodeForSession` / `verifyOtp`. The previous session-ready probe used only six short backoff attempts. `/auth/callback` also polled `getBootStateRedirect` for only a few seconds. The apply page reused the same brittle probe on submit.

What we changed

- Added `lib/auth/wait-for-server-session-ready.ts` with bounded exponential backoff + jitter (default ~40s cap).
- `app/auth/callback/page.tsx`: longer session-ready wait and extended boot redirect polling before redirect.
- `app/client/apply/page.tsx`: submit waits up to ~45s with "Finishing sign-in…" on the button; status check uses one bounded wait then fetch retries; hard-fail toast gives refresh/retry guidance.
- `tests/auth/invite-client-apply-flow.spec.ts`: increased success navigation timeout for slow cookie sync / CI.
- Documentation updates in `MVP_STATUS_NOTION.md`, `docs/DOCUMENTATION_INDEX.md`, and `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`.

Scope note: This PR merges **all commits on `develop` that are not yet on `main`** (a large delta). The bullets above describe the **latest** commit (`ad9447ee7d1bfb50dedc8b2f1dfb3b74e1fc9752`); earlier commits on the branch include UI, gigs, admin, and other work already on `develop`.

How we proved it

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass
- `npm run lint` — pass
- Repository pre-commit hook (includes build and guards) — pass on commit `ad9447ee7d1bfb50dedc8b2f1dfb3b74e1fc9752`
- Playwright invite → apply flow not re-run in this ship environment (needs local app + Supabase); spec timeout was increased for realistic session sync delays.

Docs updated: yes

- `MVP_STATUS_NOTION.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`

Risk + rollback

Risk level: Low

Rollback plan: Revert `ad9447ee7d1bfb50dedc8b2f1dfb3b74e1fc9752` if the longer waits cause an unexpected UX issue; server-side auth requirements for submit are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-invite authentication convergence logic and adds longer, structured retry/wait behavior, which can affect sign-in/callback UX and time-to-redirect. Risk is moderated by being additive and scoped, but it touches auth-adjacent routing and submission gating.
> 
> **Overview**
> Improves reliability of the invite → `/auth/callback` → `/client/apply` flow by adding a shared `waitForServerSessionReady` probe with **bounded exponential backoff + jitter** and a **per-attempt fetch timeout**, returning structured terminal outcomes for UX and logging.
> 
> `/api/auth/session-ready` now returns JSON `reason` codes and emits `logger.warn` on auth/exception failure paths. The callback and client apply pages use the new probe with longer budgets, adjust polling/redirect timing, and show more specific error/toast/button copy when server session visibility doesn’t converge in time.
> 
> Updates Playwright invite/apply test timeouts for slower cookie sync and refreshes related troubleshooting/docs status entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6733e60d4bcb7bb5938ed98e751e9521224f8a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->