### PR TITLE
fix(tooling): abort-aware session delay and scoped webpack cache

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,13 +8,27 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Bugbot follow-up — abortable delay + scoped webpack cache (April 14, 2026)**
+
+**BUILD / AUTH** — April 14, 2026
+- ✅ **`lib/auth/wait-for-server-session-ready.ts`:** `delayWithOptionalAbort` resolves immediately when the **`AbortSignal` is already aborted** (late `abort` listeners do not run on an already-aborted signal; avoids sleeping a full backoff after effect cleanup).
+- ✅ **`next.config.mjs`:** Webpack **`config.cache = false`** only for **non-dev** builds on **`win32`** or when **`DISABLE_NEXT_WEBPACK_CACHE=1`** — keeps persistent cache on **Linux CI / Vercel**; Windows long-path pack-cache workaround preserved.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 14, 2026.
+
+**Next (P0):** None.
+
+**Next (P1):** None for this patch.
+
+---
+
 ## 🚀 **Latest: Admin Users — Talent hard delete from dashboard (April 14, 2026)**
 
 **ADMIN / QA** — April 14, 2026
 - ✅ **`/admin/users`:** **Delete User** for eligible **Talent** only (confirmation + checkbox); uses **`POST /api/admin/delete-user`**; Career Builder rows remain **disable-only**; no delete for admin targets or self (server guardrails unchanged).
 - ✅ **Tests:** **`tests/helpers/seed-admin-user.ts`**, Playwright updates in **`tests/admin/admin-users-route.spec.ts`** and **`tests/admin/admin-user-lifecycle-guardrail.spec.ts`** (self-delete API guard with paginated auth user lookup).
 - ✅ **`docs/contracts/ADMIN_CONTRACT.md`:** Disable (**client**) vs hard-delete (**talent**) eligibility and manual checklist aligned with the UI.
-- ✅ **Build / types:** Production webpack **`config.cache = false`** when **`!dev`** in **`next.config.mjs`** (mitigates Windows `.next` pack rename flakiness); minimal **`pages/_app.tsx`** + **`pages/404.tsx`** so **`pages-manifest.json`** is emitted reliably; **`"terminal" in sessionProbe`** narrowing in **`app/auth/callback/page.tsx`** and **`app/client/apply/page.tsx`**; **`delayWithOptionalAbort`** **`AbortSignal`** handling in **`lib/auth/wait-for-server-session-ready.ts`**.
+- ✅ **Build / types:** Production webpack **`config.cache = false`** when **`!dev`** on **Windows** (`win32`) or **`DISABLE_NEXT_WEBPACK_CACHE=1`** in **`next.config.mjs`** (mitigates Windows `.next` pack rename flakiness; Linux/Vercel keep cache); minimal **`pages/_app.tsx`** + **`pages/404.tsx`** so **`pages-manifest.json`** is emitted reliably; **`"terminal" in sessionProbe`** narrowing in **`app/auth/callback/page.tsx`** and **`app/client/apply/page.tsx`**; **`delayWithOptionalAbort`** respects **already-aborted** **`AbortSignal`** in **`lib/auth/wait-for-server-session-ready.ts`**.
 
 **Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 14, 2026.
 

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -44,6 +44,9 @@ npm run build
 - **`tsc` / `npm run typecheck` fails with missing `app/.../page.js` under `.next/types` after deleting or moving App Router routes:** Stale Next.js generated types still reference removed files.
   - **Fix:** Delete the `.next` folder and run `npm run typecheck` (or `npm run build`) again so types regenerate from the current `app/` tree.
   - **Prevention:** After removing routes locally, run a fresh build or remove `.next` before relying on `tsc` in an old workspace.
+- **Next.js production build: webpack pack cache ENOENT / missing `.next/server/pages-manifest.json` (often Windows + long paths):** Persistent webpack filesystem cache can fail mid-build on some setups.
+  - **Fix:** Repo **`next.config.mjs`** disables webpack persistent cache for **`!dev`** on **`win32`** only (and when **`DISABLE_NEXT_WEBPACK_CACHE=1`**). On a non-Windows machine hitting the same failure, set **`DISABLE_NEXT_WEBPACK_CACHE=1`** for that build.
+  - **Prevention:** Do not force **`config.cache = false`** for all platforms unless necessary; it slows CI and Vercel.
 - **Import Path Errors:** `Module not found: Can't resolve '@/lib/supabase/supabase-admin-client'`
   - **Fix:** Use correct path `@/lib/supabase-admin-client`
 - **Missing Import Errors:** `ReferenceError: createNameSlug is not defined`

--- a/lib/auth/wait-for-server-session-ready.ts
+++ b/lib/auth/wait-for-server-session-ready.ts
@@ -62,6 +62,7 @@ function mergeAbortSignals(timeoutSignal: AbortSignal, external?: AbortSignal): 
 function delayWithOptionalAbort(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) return Promise.resolve();
   if (signal == null) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.resolve();
   const sig = signal;
   return new Promise((resolve) => {
     const onAbort = () => {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -80,7 +80,8 @@ const nextConfig = {
   webpack: (config, { isServer, dev }) => {
     // Windows + long/space paths: persistent pack cache can fail mid-build (ENOENT on rename),
     // which then surfaces as missing `.next/server/pages-manifest.json` during "Collecting page data".
-    if (!dev) {
+    // Limit to win32 (and optional DISABLE_NEXT_WEBPACK_CACHE=1) so Linux CI / Vercel keep webpack cache.
+    if (!dev && (process.platform === 'win32' || process.env.DISABLE_NEXT_WEBPACK_CACHE === '1')) {
       config.cache = false;
     }
     if (!isServer) {


### PR DESCRIPTION
What broke

- Follow-up from Cursor Bugbot review: session backoff could wait a full delay after an already-aborted `AbortSignal`, and production webpack persistent cache was disabled on every platform (not only Windows / problematic environments).

Why it broke

- Per DOM behavior, `abort` listeners added after a signal is already aborted do not run, so `delayWithOptionalAbort` could still wait on `setTimeout` until the full backoff elapsed.
- `next.config.mjs` used `config.cache = false` for all non-dev builds while the comment described a Windows long-path / pack-cache rename workaround—unnecessarily slowing Linux CI and Vercel.

What we changed

- `lib/auth/wait-for-server-session-ready.ts`: return immediately from `delayWithOptionalAbort` when `signal.aborted` before attaching listeners.
- `next.config.mjs`: apply `config.cache = false` only when `!dev` and (`process.platform === 'win32'` or `process.env.DISABLE_NEXT_WEBPACK_CACHE === '1'`).
- `MVP_STATUS_NOTION.md`: documented the Bugbot follow-up and corrected the webpack-cache note under Admin Users.
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`: noted webpack pack-cache / `pages-manifest` failures and the `DISABLE_NEXT_WEBPACK_CACHE` escape hatch.

How we proved it

- `npm run schema:verify:comprehensive` (pass)
- `npm run types:check` (pass)
- `npm run build` (pass)
- `npm run lint` (pass)
- Husky pre-commit on `git commit` re-ran guards, build, MVP doc check, and lint (pass)

Manual checks were not run in this session (no browser).

**Branch scope:** `main...develop` contains many commits beyond this patch (admin hard-delete, gig error handling, auth/session convergence, UI polish, etc.). This PR promotes the current `develop` tip; the newest commit is `fix(tooling): abort-aware delay helper and win32 webpack cache` (`c07ff10`).

Docs updated: yes

- `MVP_STATUS_NOTION.md`
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`

Risk + rollback

Risk level: Low

Rollback plan: Revert commit `c07ff10` on `develop` and redeploy, or revert the merge commit on `main` if production shows unexpected build-cache behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted fixes to an auth polling delay helper and build tooling configuration; main risk is unexpected build performance/behavior differences on non-Windows environments when toggling `DISABLE_NEXT_WEBPACK_CACHE`.
> 
> **Overview**
> Fixes two tooling edge cases affecting auth polling and production builds.
> 
> `delayWithOptionalAbort` now resolves immediately when passed an already-aborted `AbortSignal`, avoiding an unnecessary full backoff sleep after React effect cleanup. Production webpack persistent caching is no longer disabled globally; `config.cache = false` is now scoped to Windows (`win32`) and an opt-out env flag (`DISABLE_NEXT_WEBPACK_CACHE=1`).
> 
> Documentation is updated to reflect the new build-cache behavior and to add a troubleshooting entry for pack-cache ENOENT / missing `pages-manifest.json` failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07ff10c68d4437447818819bae39ff8e2bfd213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->