### PR TITLE
fix(admin): harden users list and fix dialog drawer stacking

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,23 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Admin users list load, mobile drawer, and dialog stacking (April 14, 2026)**
+
+**ADMIN / UI** — April 14, 2026
+- ✅ **`/admin/users`:** Explicit **`talent_profiles!talent_profiles_user_id_fkey`** embed; session **`profiles`** read with **service-role fallback** after admin gate; **`loadError`** banner when both reads fail; **controlled `Tabs`**; post-sync refetch retries admin read and can show a non-blocking stale-verification note.
+- ✅ **Admin + Career Builder mobile drawers:** **`DialogContent`** uses **`!fixed z-[51]`** so **`.panel-frosted`** does not override **`position: fixed`** (panel above the dim overlay).
+- ✅ **Disable / Delete confirmations on `/admin/users`:** same **`!fixed z-[51]`** on confirmation **`DialogContent`**.
+- ✅ **Tests:** **`tests/admin/admin-dashboard-overflow-sentinel.spec.ts`** asserts a **Users** link inside **`admin-drawer-panel`** (opt-in **`RUN_AUTH_OVERFLOW=1`** overflow suite).
+- ✅ **Docs:** **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`** — **`panel-frosted` + Radix Dialog** stacking.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 14, 2026.
+
+**Next (P0):** None.
+
+**Next (P1):** Optional shared dialog/drawer surface that avoids **`position: relative`** on portaled content.
+
+---
+
 ## 🚀 **Latest: Bugbot follow-up — abortable delay + scoped webpack cache (April 14, 2026)**
 
 **BUILD / AUTH** — April 14, 2026

--- a/app/admin/users/admin-users-client.tsx
+++ b/app/admin/users/admin-users-client.tsx
@@ -16,10 +16,11 @@ import {
   ArrowUp,
   Loader2,
   Trash2,
+  AlertCircle,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AdminHeader } from "@/components/admin/admin-header";
 import { MobileListRowCard } from "@/components/dashboard/mobile-list-row-card";
 import { MobileSummaryRow } from "@/components/dashboard/mobile-summary-row";
@@ -28,6 +29,7 @@ import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
 import { PageHeader } from "@/components/layout/page-header";
 import { PageShell } from "@/components/layout/page-shell";
 import { SafeDate } from "@/components/safe-date";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -71,9 +73,14 @@ type UserProfile = {
 interface AdminUsersClientProps {
   users: UserProfile[];
   user: User;
+  loadError?: string | null;
 }
 
-export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClientProps) {
+export function AdminUsersClient({
+  users: initialUsers,
+  user,
+  loadError = null,
+}: AdminUsersClientProps) {
   const router = useRouter();
   const { toast } = useToast();
   const [searchQuery, setSearchQuery] = useState("");
@@ -89,6 +96,10 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
   const [userToDelete, setUserToDelete] = useState<UserProfile | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteConfirmChecked, setDeleteConfirmChecked] = useState(false);
+
+  useEffect(() => {
+    setUsers(initialUsers);
+  }, [initialUsers]);
 
   const getUserDisplayName = (u: UserProfile) => {
     const talentName = u.talent_profiles
@@ -449,7 +460,7 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
   );
 
   const renderUsersContent = () => {
-    if (filteredUsers.length === 0) {
+    if (!loadError && filteredUsers.length === 0) {
       return (
         <div className="text-center py-10">
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-blue-500/20 to-cyan-500/20">
@@ -461,6 +472,10 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
           </p>
         </div>
       );
+    }
+
+    if (loadError && filteredUsers.length === 0) {
+      return null;
     }
 
     return (
@@ -578,6 +593,17 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
           }
         />
 
+        {loadError ? (
+          <Alert
+            variant="destructive"
+            className="border-rose-500/40 bg-rose-500/10 text-rose-100 [&>svg]:text-rose-200"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Could not load users</AlertTitle>
+            <AlertDescription>{loadError}</AlertDescription>
+          </Alert>
+        ) : null}
+
         <div className="md:hidden">
           <MobileSummaryRow
             items={[
@@ -629,7 +655,7 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
             </div>
           </div>
 
-          <Tabs defaultValue="all" className="w-full space-y-4" onValueChange={setActiveTab}>
+          <Tabs value={activeTab} className="w-full space-y-4" onValueChange={setActiveTab}>
             <div className="border-b border-white/10 px-4 sm:px-6">
               <MobileTabRail edgeColorClassName="from-[rgba(6,8,18,0.98)]">
                 <TabsList className="panel-frosted inline-flex h-auto min-w-max gap-1 rounded-xl border border-white/10 bg-white/5 p-1">
@@ -709,7 +735,7 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
 
       {/* Disable Confirmation Dialog */}
       <Dialog open={disableDialogOpen} onOpenChange={setDisableDialogOpen}>
-        <DialogContent className="panel-frosted border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
+        <DialogContent className="panel-frosted !fixed z-[51] border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
           <DialogHeader>
             <DialogTitle className="text-amber-300">Disable Career Builder</DialogTitle>
             <DialogDescription className="text-[var(--oklch-text-secondary)]">
@@ -784,7 +810,7 @@ export function AdminUsersClient({ users: initialUsers, user }: AdminUsersClient
           }
         }}
       >
-        <DialogContent className="panel-frosted border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
+        <DialogContent className="panel-frosted !fixed z-[51] border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
           <DialogHeader>
             <DialogTitle className="text-rose-300">Delete user permanently?</DialogTitle>
             <DialogDescription asChild>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -21,6 +21,26 @@ type UserProfile = {
   } | null;
 };
 
+/** Explicit FK avoids ambiguous embed errors when querying profiles → talent_profiles. */
+const PROFILE_LIST_SELECT = `
+  id,
+  role,
+  display_name,
+  is_suspended,
+  avatar_url,
+  avatar_path,
+  email_verified,
+  created_at,
+  updated_at,
+  talent_profiles!talent_profiles_user_id_fkey(first_name, last_name)
+`;
+
+function describeQueryError(err: { message?: string; code?: string }): string {
+  const msg = err.message?.trim() || "Failed to load users.";
+  const code = err.code ? ` (${err.code})` : "";
+  return `${msg}${code}`;
+}
+
 // Force dynamic rendering to prevent static pre-rendering
 export const dynamic = "force-dynamic";
 
@@ -49,32 +69,38 @@ export default async function AdminUsersPage() {
     redirect("/login?returnUrl=/admin/users");
   }
 
-  // Fetch all users with their profiles and talent profiles (if applicable)
-  const { data: profiles, error: profilesError } = await supabase
+  let loadError: string | null = null;
+  let profiles: UserProfile[] | null = null;
+
+  const sessionFetch = await supabase
     .from("profiles")
-    .select(`
-      id,
-      role,
-      display_name,
-      is_suspended,
-      avatar_url,
-      avatar_path,
-      email_verified,
-      created_at,
-      updated_at,
-      talent_profiles!left(first_name, last_name)
-    `)
+    .select(PROFILE_LIST_SELECT)
     .order("created_at", { ascending: false });
 
-  if (profilesError) {
-    logger.error("Error fetching profiles", profilesError);
-    return <AdminUsersClient users={[]} user={user} />;
+  if (sessionFetch.error) {
+    logger.error("[AdminUsersPage] Session profiles fetch failed", sessionFetch.error);
+    const adminFetch = await supabaseAdmin
+      .from("profiles")
+      .select(PROFILE_LIST_SELECT)
+      .order("created_at", { ascending: false });
+
+    if (adminFetch.error) {
+      logger.error("[AdminUsersPage] Admin profiles fetch failed", adminFetch.error);
+      loadError = describeQueryError(sessionFetch.error);
+      profiles = [];
+    } else {
+      profiles = (adminFetch.data ?? []) as UserProfile[];
+    }
+  } else {
+    profiles = (sessionFetch.data ?? []) as UserProfile[];
+  }
+
+  if (!profiles) {
+    profiles = [];
   }
 
   // Sync email verification status from auth.users.email_confirmed_at to profiles.email_verified
-  // This ensures the admin dashboard shows accurate verification status
-  if (profiles && profiles.length > 0) {
-    // Pull a large page so we don't miss users due to pagination limits
+  if (profiles.length > 0) {
     const {
       data,
       error: listError,
@@ -115,35 +141,44 @@ export default async function AdminUsersPage() {
           }
         }
 
-        // Re-fetch profiles after sync
-        const { data: syncedProfiles, error: refetchError } = await supabase
+        const refetchSession = await supabase
           .from("profiles")
-          .select(`
-            id,
-            role,
-            display_name,
-            is_suspended,
-            avatar_url,
-            avatar_path,
-            email_verified,
-            created_at,
-            updated_at,
-            talent_profiles!left(first_name, last_name)
-          `)
+          .select(PROFILE_LIST_SELECT)
           .order("created_at", { ascending: false });
 
-        if (refetchError) {
+        if (refetchSession.error) {
           logger.error(
-            "[AdminUsersPage] Error refetching profiles after sync",
-            refetchError
+            "[AdminUsersPage] Error refetching profiles after sync (session)",
+            refetchSession.error
           );
-        } else if (syncedProfiles) {
-          return <AdminUsersClient users={syncedProfiles as UserProfile[]} user={user} />;
+          const refetchAdmin = await supabaseAdmin
+            .from("profiles")
+            .select(PROFILE_LIST_SELECT)
+            .order("created_at", { ascending: false });
+
+          if (refetchAdmin.error) {
+            logger.error(
+              "[AdminUsersPage] Error refetching profiles after sync (admin)",
+              refetchAdmin.error
+            );
+            loadError =
+              loadError ??
+              "Could not refresh the user list after syncing email verification. You may still see slightly stale verification badges.";
+          } else {
+            profiles = (refetchAdmin.data ?? []) as UserProfile[];
+          }
+        } else {
+          profiles = (refetchSession.data ?? []) as UserProfile[];
         }
       }
     }
   }
 
-  return <AdminUsersClient users={(profiles || []) as UserProfile[]} user={user} />;
+  return (
+    <AdminUsersClient
+      users={profiles}
+      user={user}
+      loadError={loadError}
+    />
+  );
 }
-

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -136,7 +136,7 @@ export function AdminHeader({ user, notificationCount: notificationCountProp }: 
             </DialogTrigger>
             <DialogContent
               data-testid="admin-drawer-panel"
-              className="panel-frosted left-0 top-0 h-[100dvh] w-[min(85vw,320px)] max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-r border-white/10 bg-[var(--totl-surface-glass-strong)] p-0 pb-[env(safe-area-inset-bottom)] text-foreground"
+              className="panel-frosted !fixed z-[51] left-0 top-0 h-[100dvh] w-[min(85vw,320px)] max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-r border-white/10 bg-[var(--totl-surface-glass-strong)] p-0 pb-[env(safe-area-inset-bottom)] text-foreground"
             >
               <DialogTitle className="sr-only">Admin Navigation</DialogTitle>
               <div className="flex h-full flex-col">

--- a/components/client/client-terminal-header.tsx
+++ b/components/client/client-terminal-header.tsx
@@ -105,7 +105,7 @@ export function ClientTerminalHeader({
       <Dialog open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
         <DialogContent
           data-testid="client-drawer-panel"
-          className="panel-frosted left-0 top-0 h-[100dvh] w-[min(85vw,320px)] max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-r border-white/10 bg-[var(--totl-surface-glass-strong)] p-0 pb-[env(safe-area-inset-bottom)] text-white"
+          className="panel-frosted !fixed z-[51] left-0 top-0 h-[100dvh] w-[min(85vw,320px)] max-w-none translate-x-0 translate-y-0 overflow-hidden rounded-none border-r border-white/10 bg-[var(--totl-surface-glass-strong)] p-0 pb-[env(safe-area-inset-bottom)] text-white"
         >
           <div className="flex h-full flex-col">
             <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/10 bg-[rgba(10,10,18,0.72)] px-4 pb-3 pt-[calc(env(safe-area-inset-top)+0.75rem)] backdrop-blur-sm">

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 14, 2026 (admin `/admin/users` Talent hard delete UI + `ADMIN_CONTRACT.md`; public gig routes: `PGRST116` vs transport errors; session-ready **`AbortSignal`** / **`terminal`** narrowing; `COMMON_ERRORS_QUICK_REFERENCE.md`; prior: session-ready hardening, Bugbot triage April 12, gig marketing paywall, admin gig delete / bookings RLS)
+**Last Updated:** April 14, 2026 (admin `/admin/users` list hardening + load errors, mobile drawer / confirmation dialog **`panel-frosted`** stacking fix, `COMMON_ERRORS_QUICK_REFERENCE.md`; prior: Talent hard delete UI, public gig `PGRST116` vs transport errors, session-ready probe, Bugbot triage, gig paywall, admin gig delete RLS)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -47,6 +47,9 @@ npm run build
 - **Next.js production build: webpack pack cache ENOENT / missing `.next/server/pages-manifest.json` (often Windows + long paths):** Persistent webpack filesystem cache can fail mid-build on some setups.
   - **Fix:** Repo **`next.config.mjs`** disables webpack persistent cache for **`!dev`** on **`win32`** only (and when **`DISABLE_NEXT_WEBPACK_CACHE=1`**). On a non-Windows machine hitting the same failure, set **`DISABLE_NEXT_WEBPACK_CACHE=1`** for that build.
   - **Prevention:** Do not force **`config.cache = false`** for all platforms unless necessary; it slows CI and Vercel.
+- **Radix Dialog / drawer: full-screen dim overlay but no visible panel (“black screen”):** `DialogContent` is **`fixed`** + **`z-50`** in **`components/ui/dialog.tsx`**, but **`.panel-frosted`** in **`app/globals.css`** sets **`position: relative`** in **`@layer utilities`** after **`@tailwind utilities`**, so **`relative` can win** over **`fixed`** on the same node. The overlay stays **`fixed inset-0`**, while the panel is not stacked as intended.
+  - **Fix:** On affected **`DialogContent`** instances, add **`!fixed z-[51]`** (or any **`z` strictly above the overlay**) so the panel stays fixed and paints above the backdrop. Used for admin/client mobile nav drawers and admin users disable/delete confirmations.
+  - **Prevention:** Prefer a composable surface class that does not set **`position`** when used on portaled overlays, or document that **`panel-frosted` + Dialog** must pair with **`!fixed`**.
 - **Import Path Errors:** `Module not found: Can't resolve '@/lib/supabase/supabase-admin-client'`
   - **Fix:** Use correct path `@/lib/supabase-admin-client`
 - **Missing Import Errors:** `ReferenceError: createNameSlug is not defined`

--- a/tests/admin/admin-dashboard-overflow-sentinel.spec.ts
+++ b/tests/admin/admin-dashboard-overflow-sentinel.spec.ts
@@ -65,7 +65,11 @@ test.describe("Admin overflow sentinel (mobile)", () => {
     await expect(page.locator('[data-testid="admin-drawer-trigger"]')).toBeVisible({ timeout: 60_000 });
     await expect(page.locator('[data-testid="admin-overflow-trigger"]')).toBeVisible({ timeout: 60_000 });
     await page.locator('[data-testid="admin-drawer-trigger"]').click();
-    await expect(page.locator('[data-testid="admin-drawer-panel"]')).toBeVisible({ timeout: 60_000 });
+    const drawerPanel = page.locator('[data-testid="admin-drawer-panel"]');
+    await expect(drawerPanel).toBeVisible({ timeout: 60_000 });
+    await expect(
+      drawerPanel.getByRole("link", { name: "Users", exact: true })
+    ).toBeVisible({ timeout: 30_000 });
     await expectNoHorizontalOverflow(page, "admin dashboard");
   });
 });


### PR DESCRIPTION
## What broke

- **`/admin/users`** could look empty or broken when the **`profiles`** query failed (errors were swallowed as an empty list). The **`talent_profiles`** embed could also fail without an explicit FK hint. In some environments the **session-scoped** read could fail while a **service-role** read would succeed after the admin gate.
- **Mobile admin** and **Career Builder** **hamburger** drawers, plus **Disable** / **Delete user** confirmation dialogs on **`/admin/users`**, showed a **full-screen dim overlay** with **no visible panel** (content not stacked above the overlay).

## Why it broke

- Server page passed **`users={[]}`** on **`profiles`** error, same as a truly empty database.
- **`.panel-frosted`** in **`app/globals.css`** sets **`position: relative`** in **`@layer utilities`** after **`@tailwind utilities`**, which can **override** **`DialogContent`’s `fixed`** from **`components/ui/dialog.tsx`**. The **overlay** stays **`fixed` + `z-50`** while the **panel** is no longer layered correctly.

## What we changed

- **`app/admin/users/page.tsx`:** Explicit **`talent_profiles!talent_profiles_user_id_fkey`** embed; **session** fetch with **service-role fallback** after admin check; **`loadError`** passed to the client; post–email-sync refetch retries **admin** read; logging preserved.
- **`app/admin/users/admin-users-client.tsx`:** **`loadError`** **`Alert`**; **controlled `Tabs`**; sync **`users`** from server props; **`!fixed z-[51]`** on **Disable** and **Delete** **`DialogContent`**.
- **`components/admin/admin-header.tsx`** and **`components/client/client-terminal-header.tsx`:** **`!fixed z-[51]`** on mobile drawer **`DialogContent`**.
- **`tests/admin/admin-dashboard-overflow-sentinel.spec.ts`:** Assert **Users** link visible inside **`admin-drawer-panel`**.
- **Docs:** **`MVP_STATUS_NOTION.md`**, **`docs/DOCUMENTATION_INDEX.md`**, **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`** (`panel-frosted` + Radix Dialog).

## How we proved it

- **`npm run schema:verify:comprehensive`** — pass
- **`npm run types:check`** — pass
- **`npm run build`** — pass (also run again during **`git commit`** pre-commit hook)
- **`npm run lint`** — pass (also run in pre-commit)
- **Playwright:** **`tests/admin/admin-users-route.spec.ts`** — 8 passed (earlier in this workstream before final commit; not re-run after push)

**Manual:** Not run from CI/agent (please smoke **Delete** / **Disable** dialogs and mobile drawer on staging).

**Branch scope:** **`main...develop`** contains **many commits** beyond this patch; this PR merges the **full** develop branch, not this session only.

## Docs updated: yes

- **`MVP_STATUS_NOTION.md`**
- **`docs/DOCUMENTATION_INDEX.md`**
- **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`**

## Risk + rollback

**Risk level:** Low

**Rollback plan:** Revert commit **`515cf46`** on **`develop`** or deploy the previous production revision; no schema migrations in this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin data-fetching and introduces a service-role fallback for `/admin/users`, which could affect what data is shown if the admin gate or query logic is wrong; also changes dialog positioning/z-index across mobile drawers and confirmations.
> 
> **Overview**
> Improves `/admin/users` reliability by using an explicit `talent_profiles` FK embed, adding a session read with service-role fallback, and surfacing a `loadError` banner instead of silently rendering an empty list; post email-verification sync now retries refetch via the admin client and may show a non-blocking stale-data note.
> 
> Fixes Radix `DialogContent` stacking for mobile drawers and `/admin/users` disable/delete confirmations by forcing `!fixed z-[51]` so `panel-frosted` doesn’t override positioning, and tightens the overflow sentinel Playwright test to assert the **Users** link is visible inside the admin drawer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515cf46bd9e6c03a176ebdb74f2251191b78185a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->