### PR TITLE
fix(admin): reversible suspend and reinstate for Talent and Career Builder

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,12 +8,29 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Admin Users — reversible suspend / reinstate (April 14, 2026)**
+
+**ADMIN / API / QA** — April 14, 2026
+- ✅ **`POST /api/admin/set-user-suspension`:** canonical body `{ userId, suspended: boolean, reason? }`; **Talent** and **Career Builder** targets only; blocks **self** and **admin** targets; suspend sets `profiles.is_suspended` (+ optional `suspension_reason`); reinstate sets `is_suspended = false` and clears `suspension_reason`.
+- ✅ **`POST /api/admin/disable-user`:** thin backward-compatible wrapper (treats omitted `suspended` as `true`).
+- ✅ **`/admin/users`:** **Suspend User** / **Reinstate User** in the actions menu with confirmation dialogs; **hard delete** remains **Talent-only** and separate; Career Builder hard delete still **409** with guidance to use **Suspend User**.
+- ✅ **Tests:** `tests/admin/admin-user-lifecycle-guardrail.spec.ts`, `tests/admin/admin-users-route.spec.ts` (suspend/reinstate flows, admin row guardrails).
+- ✅ **Docs:** `docs/contracts/ADMIN_CONTRACT.md`, `docs/journeys/ADMIN_JOURNEY.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 14, 2026.
+
+**Next (P0):** Merge **develop → main** via PR; smoke **Suspend User** / **Reinstate User** on staging for Talent + Career Builder.
+
+**Next (P1):** Optional **admin-account** suspension only if product/compliance explicitly requires it (currently blocked end-to-end).
+
+---
+
 ## 🚀 **Latest: Admin users list load, mobile drawer, and dialog stacking (April 14, 2026)**
 
 **ADMIN / UI** — April 14, 2026
 - ✅ **`/admin/users`:** Explicit **`talent_profiles!talent_profiles_user_id_fkey`** embed; session **`profiles`** read with **service-role fallback** after admin gate; **`loadError`** banner when both reads fail; **controlled `Tabs`**; post-sync refetch retries admin read and can show a non-blocking stale-verification note.
 - ✅ **Admin + Career Builder mobile drawers:** **`DialogContent`** uses **`!fixed z-[51]`** so **`.panel-frosted`** does not override **`position: fixed`** (panel above the dim overlay).
-- ✅ **Disable / Delete confirmations on `/admin/users`:** same **`!fixed z-[51]`** on confirmation **`DialogContent`**.
+- ✅ **Suspend / Reinstate / Delete confirmations on `/admin/users`:** same **`!fixed z-[51]`** on confirmation **`DialogContent`**.
 - ✅ **Tests:** **`tests/admin/admin-dashboard-overflow-sentinel.spec.ts`** asserts a **Users** link inside **`admin-drawer-panel`** (opt-in **`RUN_AUTH_OVERFLOW=1`** overflow suite).
 - ✅ **Docs:** **`docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`** — **`panel-frosted` + Radix Dialog** stacking.
 
@@ -42,7 +59,7 @@
 ## 🚀 **Latest: Admin Users — Talent hard delete from dashboard (April 14, 2026)**
 
 **ADMIN / QA** — April 14, 2026
-- ✅ **`/admin/users`:** **Delete User** for eligible **Talent** only (confirmation + checkbox); uses **`POST /api/admin/delete-user`**; Career Builder rows remain **disable-only**; no delete for admin targets or self (server guardrails unchanged).
+- ✅ **`/admin/users`:** **Delete User** for eligible **Talent** only (confirmation + checkbox); uses **`POST /api/admin/delete-user`**; Career Builder rows use **suspend** (reversible), not hard delete; no delete for admin targets or self (server guardrails unchanged).
 - ✅ **Tests:** **`tests/helpers/seed-admin-user.ts`**, Playwright updates in **`tests/admin/admin-users-route.spec.ts`** and **`tests/admin/admin-user-lifecycle-guardrail.spec.ts`** (self-delete API guard with paginated auth user lookup).
 - ✅ **`docs/contracts/ADMIN_CONTRACT.md`:** Disable (**client**) vs hard-delete (**talent**) eligibility and manual checklist aligned with the UI.
 - ✅ **Build / types:** Production webpack **`config.cache = false`** when **`!dev`** on **Windows** (`win32`) or **`DISABLE_NEXT_WEBPACK_CACHE=1`** in **`next.config.mjs`** (mitigates Windows `.next` pack rename flakiness; Linux/Vercel keep cache); minimal **`pages/_app.tsx`** + **`pages/404.tsx`** so **`pages-manifest.json`** is emitted reliably; **`"terminal" in sessionProbe`** narrowing in **`app/auth/callback/page.tsx`** and **`app/client/apply/page.tsx`**; **`delayWithOptionalAbort`** respects **already-aborted** **`AbortSignal`** in **`lib/auth/wait-for-server-session-ready.ts`**.

--- a/app/admin/users/admin-users-client.tsx
+++ b/app/admin/users/admin-users-client.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
   Trash2,
   AlertCircle,
+  Undo2,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -86,11 +87,15 @@ export function AdminUsersClient({
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState("all");
   const [users, setUsers] = useState(initialUsers);
-  const [disableDialogOpen, setDisableDialogOpen] = useState(false);
-  const [userToDisable, setUserToDisable] = useState<UserProfile | null>(null);
-  const [isDisabling, setIsDisabling] = useState(false);
-  const [disableConfirmChecked, setDisableConfirmChecked] = useState(false);
-  const [disableReason, setDisableReason] = useState("");
+  const [suspendDialogOpen, setSuspendDialogOpen] = useState(false);
+  const [userToSuspend, setUserToSuspend] = useState<UserProfile | null>(null);
+  const [isSuspending, setIsSuspending] = useState(false);
+  const [suspendConfirmChecked, setSuspendConfirmChecked] = useState(false);
+  const [suspendReason, setSuspendReason] = useState("");
+  const [reinstateDialogOpen, setReinstateDialogOpen] = useState(false);
+  const [userToReinstate, setUserToReinstate] = useState<UserProfile | null>(null);
+  const [isReinstating, setIsReinstating] = useState(false);
+  const [reinstateConfirmChecked, setReinstateConfirmChecked] = useState(false);
   const [isUpdatingRole, setIsUpdatingRole] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [userToDelete, setUserToDelete] = useState<UserProfile | null>(null);
@@ -162,6 +167,16 @@ export function AdminUsersClient({
   const canShowHardDelete = (target: UserProfile) =>
     target.role === "talent" && target.id !== user.id;
 
+  const canSuspendUser = (target: UserProfile) =>
+    target.id !== user.id &&
+    (target.role === "talent" || target.role === "client") &&
+    target.is_suspended !== true;
+
+  const canReinstateUser = (target: UserProfile) =>
+    target.id !== user.id &&
+    (target.role === "talent" || target.role === "client") &&
+    target.is_suspended === true;
+
   const handleDeleteUser = async () => {
     if (!userToDelete || !deleteConfirmChecked) return;
 
@@ -210,7 +225,7 @@ export function AdminUsersClient({
         description = "Cannot delete your own account.";
       } else if (userProfile.role === "client") {
         description =
-          "Hard delete is not available for Career Builder accounts. Use Disable Career Builder instead.";
+          "Hard delete is not available for Career Builder accounts. Use Suspend User instead.";
       } else if (userProfile.role === "admin") {
         description = "Cannot hard-delete admin accounts.";
       }
@@ -226,50 +241,99 @@ export function AdminUsersClient({
     setDeleteDialogOpen(true);
   };
 
-  const handleDisableUser = async () => {
-    if (!userToDisable || !disableConfirmChecked) return;
+  const handleSuspendUser = async () => {
+    if (!userToSuspend || !suspendConfirmChecked) return;
 
-    const userIdToDisable = userToDisable.id;
-    const reasonToSend = disableReason.trim();
+    const userIdToSuspend = userToSuspend.id;
+    const reasonToSend = suspendReason.trim();
 
-    setIsDisabling(true);
+    setIsSuspending(true);
     try {
-      const response = await fetch("/api/admin/disable-user", {
+      const response = await fetch("/api/admin/set-user-suspension", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userId: userIdToDisable, reason: reasonToSend || undefined }),
+        body: JSON.stringify({
+          userId: userIdToSuspend,
+          suspended: true,
+          reason: reasonToSend || undefined,
+        }),
       });
 
-      const data = await response.json();
+      const data = (await response.json()) as { error?: string; message?: string };
       if (!response.ok) {
-        throw new Error(data.error || "Failed to disable Career Builder");
+        throw new Error(data.error || "Failed to suspend user");
       }
 
       toast({
         title: "Success",
-        description: data.message || "Career Builder account disabled successfully.",
+        description: data.message || "User suspended successfully.",
         variant: "success",
       });
 
       setUsers((prevUsers) =>
         prevUsers.map((profile) =>
-          profile.id === userIdToDisable ? { ...profile, is_suspended: true } : profile
+          profile.id === userIdToSuspend ? { ...profile, is_suspended: true } : profile
         )
       );
-      setDisableDialogOpen(false);
-      setUserToDisable(null);
-      setDisableConfirmChecked(false);
-      setDisableReason("");
+      setSuspendDialogOpen(false);
+      setUserToSuspend(null);
+      setSuspendConfirmChecked(false);
+      setSuspendReason("");
       router.refresh();
     } catch (error) {
-      logger.error("Error disabling Career Builder account", error);
+      logger.error("Error suspending user", error);
       toast({
         title: "Error",
-        description: error instanceof Error ? error.message : "Failed to disable Career Builder",
+        description: error instanceof Error ? error.message : "Failed to suspend user",
         variant: "destructive",
       });
     } finally {
-      setIsDisabling(false);
+      setIsSuspending(false);
+    }
+  };
+
+  const handleReinstateUser = async () => {
+    if (!userToReinstate || !reinstateConfirmChecked) return;
+
+    const userIdToReinstate = userToReinstate.id;
+
+    setIsReinstating(true);
+    try {
+      const response = await fetch("/api/admin/set-user-suspension", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: userIdToReinstate, suspended: false }),
+      });
+
+      const data = (await response.json()) as { error?: string; message?: string };
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to reinstate user");
+      }
+
+      toast({
+        title: "Success",
+        description: data.message || "User reinstated successfully.",
+        variant: "success",
+      });
+
+      setUsers((prevUsers) =>
+        prevUsers.map((profile) =>
+          profile.id === userIdToReinstate ? { ...profile, is_suspended: false } : profile
+        )
+      );
+      setReinstateDialogOpen(false);
+      setUserToReinstate(null);
+      setReinstateConfirmChecked(false);
+      router.refresh();
+    } catch (error) {
+      logger.error("Error reinstating user", error);
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to reinstate user",
+        variant: "destructive",
+      });
+    } finally {
+      setIsReinstating(false);
     }
   };
 
@@ -312,27 +376,39 @@ export function AdminUsersClient({
     }
   };
 
-  const openDisableDialog = (userProfile: UserProfile) => {
-    if (userProfile.id === user.id) {
+  const openSuspendDialog = (userProfile: UserProfile) => {
+    if (!canSuspendUser(userProfile)) {
       toast({
         title: "Error",
-        description: "Cannot disable your own account",
+        description:
+          userProfile.id === user.id
+            ? "Cannot suspend your own account."
+            : "Suspend is only available for Talent and Career Builder accounts.",
         variant: "destructive",
       });
       return;
     }
-    if (userProfile.role !== "client") {
+    setUserToSuspend(userProfile);
+    setSuspendReason("");
+    setSuspendConfirmChecked(false);
+    setSuspendDialogOpen(true);
+  };
+
+  const openReinstateDialog = (userProfile: UserProfile) => {
+    if (!canReinstateUser(userProfile)) {
       toast({
         title: "Error",
-        description: "Disable is only available for Career Builder accounts.",
+        description:
+          userProfile.id === user.id
+            ? "Cannot reinstate your own account."
+            : "Reinstate is only available for suspended Talent and Career Builder accounts.",
         variant: "destructive",
       });
       return;
     }
-    setUserToDisable(userProfile);
-    setDisableReason("");
-    setDisableConfirmChecked(false);
-    setDisableDialogOpen(true);
+    setUserToReinstate(userProfile);
+    setReinstateConfirmChecked(false);
+    setReinstateDialogOpen(true);
   };
 
   const getRoleIcon = (role: string) => {
@@ -430,6 +506,30 @@ export function AdminUsersClient({
             Promote to Talent
           </DropdownMenuItem>
         )}
+        {canSuspendUser(userProfile) && (
+          <>
+            <DropdownMenuSeparator className="bg-white/10" />
+            <DropdownMenuItem
+              onClick={() => openSuspendDialog(userProfile)}
+              className="flex items-center text-amber-300 hover:bg-white/10"
+            >
+              <Shield className="mr-2 h-4 w-4" />
+              Suspend User
+            </DropdownMenuItem>
+          </>
+        )}
+        {canReinstateUser(userProfile) && (
+          <>
+            <DropdownMenuSeparator className="bg-white/10" />
+            <DropdownMenuItem
+              onClick={() => openReinstateDialog(userProfile)}
+              className="flex items-center text-emerald-300 hover:bg-white/10"
+            >
+              <Undo2 className="mr-2 h-4 w-4" />
+              Reinstate User
+            </DropdownMenuItem>
+          </>
+        )}
         {canShowHardDelete(userProfile) && (
           <>
             <DropdownMenuSeparator className="bg-white/10" />
@@ -439,19 +539,6 @@ export function AdminUsersClient({
             >
               <Trash2 className="mr-2 h-4 w-4" />
               Delete User
-            </DropdownMenuItem>
-          </>
-        )}
-        {userProfile.id !== user.id && userProfile.role === "client" && (
-          <>
-            <DropdownMenuSeparator className="bg-white/10" />
-            <DropdownMenuItem
-              onClick={() => openDisableDialog(userProfile)}
-              disabled={Boolean(userProfile.is_suspended)}
-              className="flex items-center text-amber-300 hover:bg-white/10"
-            >
-              <Shield className="mr-2 h-4 w-4" />
-              {userProfile.is_suspended ? "Already Suspended" : "Disable Career Builder"}
             </DropdownMenuItem>
           </>
         )}
@@ -733,65 +820,142 @@ export function AdminUsersClient({
         </div>
       </div>
 
-      {/* Disable Confirmation Dialog */}
-      <Dialog open={disableDialogOpen} onOpenChange={setDisableDialogOpen}>
+      {/* Suspend User */}
+      <Dialog
+        open={suspendDialogOpen}
+        onOpenChange={(open) => {
+          if (!open && isSuspending) return;
+          setSuspendDialogOpen(open);
+          if (!open) {
+            setUserToSuspend(null);
+            setSuspendConfirmChecked(false);
+            setSuspendReason("");
+          }
+        }}
+      >
         <DialogContent className="panel-frosted !fixed z-[51] border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
           <DialogHeader>
-            <DialogTitle className="text-amber-300">Disable Career Builder</DialogTitle>
+            <DialogTitle className="text-amber-300">Suspend User</DialogTitle>
             <DialogDescription className="text-[var(--oklch-text-secondary)]">
-              This will suspend the selected Career Builder account and prevent access to protected
-              routes until reinstated.
+              This suspends the account: the user will be signed out from protected areas and blocked
+              from signing in or accessing the app until you reinstate them. They will see the
+              standard suspended experience.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="space-y-2">
-              <p className="text-sm text-[var(--oklch-text-secondary)]">Optional reason shown on the suspended page:</p>
+              <p className="text-sm text-[var(--oklch-text-secondary)]">
+                Optional reason (shown on the suspended page):
+              </p>
               <Input
-                value={disableReason}
-                onChange={(event) => setDisableReason(event.target.value)}
+                value={suspendReason}
+                onChange={(event) => setSuspendReason(event.target.value)}
                 placeholder="Policy violation, fraud risk, or internal note..."
-                className=""
-                disabled={isDisabling}
+                disabled={isSuspending}
               />
             </div>
             <div className="flex items-start gap-3 text-sm text-[var(--oklch-text-secondary)]">
               <Checkbox
-                aria-label="Confirm disable Career Builder account"
-                checked={disableConfirmChecked}
-                onCheckedChange={(checked) => setDisableConfirmChecked(checked === true)}
-                disabled={isDisabling}
+                aria-label="Confirm suspend user account"
+                checked={suspendConfirmChecked}
+                onCheckedChange={(checked) => setSuspendConfirmChecked(checked === true)}
+                disabled={isSuspending}
               />
-              <span>I understand this will immediately block this account from dashboard access.</span>
+              <span>I understand this will immediately block this account until reinstated.</span>
             </div>
           </div>
           <DialogFooter>
             <Button
               variant="outline"
               onClick={() => {
-                setDisableDialogOpen(false);
-                setUserToDisable(null);
-                setDisableConfirmChecked(false);
-                setDisableReason("");
+                setSuspendDialogOpen(false);
+                setUserToSuspend(null);
+                setSuspendConfirmChecked(false);
+                setSuspendReason("");
               }}
-              disabled={isDisabling}
+              disabled={isSuspending}
               className="border-white/10 bg-white/5 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white"
             >
               Cancel
             </Button>
             <Button
-              onClick={handleDisableUser}
-              disabled={isDisabling || !disableConfirmChecked}
+              onClick={handleSuspendUser}
+              disabled={isSuspending || !suspendConfirmChecked}
               className="bg-amber-600 hover:bg-amber-700 text-white"
             >
-              {isDisabling ? (
+              {isSuspending ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Disabling...
+                  Suspending...
                 </>
               ) : (
                 <>
                   <Shield className="mr-2 h-4 w-4" />
-                  Disable Career Builder
+                  Suspend User
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Reinstate User */}
+      <Dialog
+        open={reinstateDialogOpen}
+        onOpenChange={(open) => {
+          if (!open && isReinstating) return;
+          setReinstateDialogOpen(open);
+          if (!open) {
+            setUserToReinstate(null);
+            setReinstateConfirmChecked(false);
+          }
+        }}
+      >
+        <DialogContent className="panel-frosted !fixed z-[51] border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
+          <DialogHeader>
+            <DialogTitle className="text-emerald-300">Reinstate User</DialogTitle>
+            <DialogDescription className="text-[var(--oklch-text-secondary)]">
+              This removes the suspension so the user can sign in and use the app again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="flex items-start gap-3 text-sm text-[var(--oklch-text-secondary)]">
+              <Checkbox
+                aria-label="Confirm reinstate user account"
+                checked={reinstateConfirmChecked}
+                onCheckedChange={(checked) => setReinstateConfirmChecked(checked === true)}
+                disabled={isReinstating}
+              />
+              <span>I understand this will restore access for this account.</span>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setReinstateDialogOpen(false);
+                setUserToReinstate(null);
+                setReinstateConfirmChecked(false);
+              }}
+              disabled={isReinstating}
+              className="border-white/10 bg-white/5 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleReinstateUser}
+              disabled={isReinstating || !reinstateConfirmChecked}
+              className="bg-emerald-600 hover:bg-emerald-700 text-white"
+            >
+              {isReinstating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Reinstating...
+                </>
+              ) : (
+                <>
+                  <Undo2 className="mr-2 h-4 w-4" />
+                  Reinstate User
                 </>
               )}
             </Button>

--- a/app/api/admin/delete-user/route.ts
+++ b/app/api/admin/delete-user/route.ts
@@ -90,7 +90,7 @@ export const POST = async (request: Request) => {
       return NextResponse.json(
         {
           error:
-            "Hard delete is blocked for Career Builder accounts because dependent records can violate foreign key constraints. Use Disable Career Builder instead.",
+            "Hard delete is blocked for Career Builder accounts because dependent records can violate foreign key constraints. Use Suspend User instead.",
         },
         { status: 409 }
       );

--- a/app/api/admin/set-user-suspension/route.ts
+++ b/app/api/admin/set-user-suspension/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 import { handleAdminSetUserSuspension } from "@/lib/api/admin-set-user-suspension";
 
-/**
- * Legacy alias: defaults to suspend (suspended=true) when body omits `suspended`.
- * Prefer POST /api/admin/set-user-suspension for explicit suspend/reinstate.
- */
 export async function POST(request: Request) {
   try {
     const body = (await request.json()) as {
@@ -14,10 +10,24 @@ export async function POST(request: Request) {
     };
 
     const userId = typeof body.userId === "string" ? body.userId.trim() : "";
-    const suspended = typeof body.suspended === "boolean" ? body.suspended : true;
+    if (!userId) {
+      return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+    }
+
+    if (typeof body.suspended !== "boolean") {
+      return NextResponse.json(
+        { error: "Field \"suspended\" must be a boolean" },
+        { status: 400 }
+      );
+    }
+
     const reason = typeof body.reason === "string" ? body.reason : undefined;
 
-    return handleAdminSetUserSuspension({ userId, suspended, reason });
+    return handleAdminSetUserSuspension({
+      userId,
+      suspended: body.suspended,
+      reason,
+    });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Unknown error" },

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 14, 2026 (admin `/admin/users` list hardening + load errors, mobile drawer / confirmation dialog **`panel-frosted`** stacking fix, `COMMON_ERRORS_QUICK_REFERENCE.md`; prior: Talent hard delete UI, public gig `PGRST116` vs transport errors, session-ready probe, Bugbot triage, gig paywall, admin gig delete RLS)
+**Last Updated:** April 14, 2026 (admin **Suspend User** / **Reinstate User** + `set-user-suspension` API; prior: `/admin/users` list hardening, mobile drawer / confirmation dialog **`panel-frosted`** stacking, Talent hard delete UI, public gig `PGRST116` vs transport errors, session-ready probe)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/contracts/ADMIN_CONTRACT.md
+++ b/docs/contracts/ADMIN_CONTRACT.md
@@ -30,7 +30,8 @@
 ### API routes (admin)
 - `/api/admin/create-user`
 - `/api/admin/delete-user`
-- `/api/admin/disable-user`
+- `/api/admin/disable-user` (legacy; defaults to suspend when `suspended` omitted)
+- `/api/admin/set-user-suspension` (canonical suspend / reinstate)
 - `/api/admin/invite-career-builder`
 - `/api/admin/update-user-role`
 - `/api/admin/check-auth-schema`
@@ -109,11 +110,11 @@
     - session via `createSupabaseServer()` and `auth.getUser()`
     - admin role via `profiles.role = 'admin'`
   - Admin user lifecycle guardrails:
-    - **Disable (suspend):** target must be `profiles.role = 'client'` (Career Builder); writes `profiles.is_suspended = true`
+    - **Suspend / reinstate:** targets must be `profiles.role` in `('talent','client')`; writes `profiles.is_suspended` and optional `suspension_reason` on suspend; reinstate clears `suspension_reason`. Use **`POST /api/admin/set-user-suspension`** with `{ userId, suspended: boolean, reason? }`. **`POST /api/admin/disable-user`** remains a backward-compatible alias (omit `suspended` → suspend). **Admin** profile targets are rejected (400). **Self** actions rejected (400).
     - **Hard delete (admin workflow):** target must be `profiles.role = 'talent'`; uses `POST /api/admin/delete-user` (auth user delete + DB cascades)
-    - admin cannot disable or hard-delete self
+    - admin cannot suspend, reinstate, or hard-delete self
     - admin cannot hard-delete another admin
-    - hard delete for Career Builder accounts is blocked (409); disable is the official policy because dependent rows can violate FK constraints
+    - hard delete for Career Builder accounts is blocked (409); **suspend** is the official reversible policy because dependent rows can violate FK constraints on auth user delete
 
 ---
 
@@ -164,20 +165,20 @@
 - Non-admin cannot access `/admin/*`.
 - Admin can:
   - approve client applications (promotion)
-  - suspend/reinstate accounts
-  - disable Career Builder accounts from `/admin/users`
+  - suspend/reinstate Talent and Career Builder accounts from `/admin/users` (reversible; `profiles.is_suspended`)
   - hard-delete eligible Talent accounts from `/admin/users` (confirmed destructive action)
   - close gigs via moderation
 
 ### Manual test steps
 - Login as admin → visit `/admin/dashboard`.
 - Login as admin → visit `/admin/users` and verify:
-  - Career Builder (`client`) rows expose `Disable Career Builder` and do **not** expose `Delete User`
-  - Talent rows expose `Delete User` (confirmation + checkbox required) and do **not** expose disable
-  - Admin rows do **not** expose `Delete User`
-  - disabling a client sets `profiles.is_suspended = true`
-  - a disabled client is routed to `/suspended` on next protected navigation
-  - hard delete for Career Builder targets fails with explicit guidance to disable instead (API or UI should surface the same policy)
+  - Career Builder (`client`) rows expose **Suspend User** (when active) and do **not** expose `Delete User`
+  - Talent rows expose **Suspend User** (when active) and `Delete User` (confirmation + checkbox required)
+  - Admin rows do **not** expose `Delete User`, **Suspend User**, or **Reinstate User**
+  - Suspending sets `profiles.is_suspended = true` (optional reason → `suspension_reason`)
+  - **Reinstate User** (Suspended tab) sets `is_suspended = false` and clears `suspension_reason`
+  - a suspended user is routed to `/suspended` on next protected navigation (existing middleware)
+  - hard delete for Career Builder targets fails with explicit guidance to **suspend** instead (API or UI should surface the same policy)
 - Approve a `client_applications` row → verify:
   - `client_applications.status='approved'`
   - `profiles.role='client' AND profiles.account_type='client'`

--- a/docs/journeys/ADMIN_JOURNEY.md
+++ b/docs/journeys/ADMIN_JOURNEY.md
@@ -27,7 +27,7 @@
 
 ### 3) Manage users
 - **Routes:** `/admin/users` (+ API routes)
-- **Writes:** Supabase Auth admin operations (create/delete) + profile suspension (`disable-user`)
+- **Writes:** Supabase Auth admin operations (create/delete) + profile suspension / reinstate (`set-user-suspension`; legacy `disable-user` wrapper)
 - **Contracts:** `docs/contracts/ADMIN_CONTRACT.md`
 
 ### 4) Moderate content

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -333,7 +333,7 @@ npm run build
 - **Career Builder hard delete fails with FK error (`SQLSTATE 23503`, `client_applications_user_id_fkey`):**
   - **Symptom:** Admin attempts to delete a Career Builder and the database rejects deleting `auth.users` because `client_applications.user_id` still references that user.
   - **Root Cause:** Career Builder accounts can own dependent rows that are not safe to remove via auth-user deletion from the Admin Users workflow.
-  - **Fix:** Treat `Disable Career Builder` (`profiles.is_suspended = true`) as the official admin action and block Career Builder hard delete with a clear “Use Disable Career Builder instead” message.
+  - **Fix:** Use **Suspend User** from `/admin/users` (`profiles.is_suspended = true`; reversible). Career Builder hard delete stays blocked (409) with guidance to **suspend** instead of delete.
   - **Prevention:** Do not use hard delete for Career Builder accounts in admin UX unless a future scoped cleanup flow first proves FK-safe dependency handling.
 - **Mobile route contract suite fails with `Login failed: Invalid credentials` across many Client/Talent specs:**
   - **Symptom:** `test:qa:mobile-guardrails`, `client-routes`, or `talent-routes` fail before route assertions run, often across many specs at once.

--- a/lib/api/admin-set-user-suspension.ts
+++ b/lib/api/admin-set-user-suspension.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServer } from "@/lib/supabase/supabase-server";
+import { createSupabaseAdminClient } from "@/lib/supabase-admin-client";
+import { logger } from "@/lib/utils/logger";
+
+type SupabaseLikeError = { message?: string };
+
+function isMissingSuspensionReasonColumnError(error: SupabaseLikeError): boolean {
+  const message = String(error?.message ?? "");
+  return /column/i.test(message) && /suspension_reason/i.test(message);
+}
+
+export type AdminSetUserSuspensionInput = {
+  userId: string;
+  suspended: boolean;
+  reason?: string;
+};
+
+/**
+ * Admin-only: set profiles.is_suspended for Talent or Career Builder (client) accounts.
+ * Does not support admin targets. Blocks acting on the requester's own account.
+ */
+export async function handleAdminSetUserSuspension(
+  input: AdminSetUserSuspensionInput
+): Promise<NextResponse> {
+  const userId = input.userId.trim();
+  const wantSuspend = input.suspended;
+  const reason = typeof input.reason === "string" ? input.reason.trim() : "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: requesterProfile, error: requesterError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (requesterError) {
+    return NextResponse.json({ error: "Failed to verify admin permissions" }, { status: 500 });
+  }
+
+  if (!requesterProfile || requesterProfile.role !== "admin") {
+    return NextResponse.json({ error: "Forbidden: Admin access required" }, { status: 403 });
+  }
+
+  if (userId === user.id) {
+    return NextResponse.json(
+      { error: "Cannot suspend or reinstate your own account" },
+      { status: 400 }
+    );
+  }
+
+  const supabaseAdmin = createSupabaseAdminClient();
+  const { data: targetProfile, error: targetError } = await supabaseAdmin
+    .from("profiles")
+    .select("id, role, is_suspended")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (targetError) {
+    return NextResponse.json({ error: "Failed to load target profile" }, { status: 500 });
+  }
+
+  if (!targetProfile) {
+    return NextResponse.json({ error: "Target user not found" }, { status: 404 });
+  }
+
+  if (targetProfile.role === "admin") {
+    return NextResponse.json(
+      { error: "Suspension is not available for admin accounts" },
+      { status: 400 }
+    );
+  }
+
+  if (targetProfile.role !== "talent" && targetProfile.role !== "client") {
+    return NextResponse.json(
+      { error: "Suspension is only available for Talent and Career Builder accounts" },
+      { status: 400 }
+    );
+  }
+
+  if (wantSuspend) {
+    if (targetProfile.is_suspended) {
+      return NextResponse.json({
+        success: true,
+        message: "Account is already suspended.",
+      });
+    }
+
+    const payload: Record<string, unknown> = { is_suspended: true };
+    if (reason) {
+      payload.suspension_reason = reason;
+    }
+
+    let { error: updateError } = await supabaseAdmin
+      .from("profiles")
+      .update(payload)
+      .eq("id", userId);
+
+    if (updateError && reason && isMissingSuspensionReasonColumnError(updateError as SupabaseLikeError)) {
+      const retry = await supabaseAdmin.from("profiles").update({ is_suspended: true }).eq("id", userId);
+      updateError = retry.error;
+    }
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 });
+    }
+
+    logger.info("[AdminSetUserSuspension] Suspended user", {
+      actor_id: user.id,
+      target_user_id: userId,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "User suspended successfully.",
+    });
+  }
+
+  // Reinstate
+  if (!targetProfile.is_suspended) {
+    return NextResponse.json({
+      success: true,
+      message: "Account is already active.",
+    });
+  }
+
+  const { error: reinstateError } = await supabaseAdmin
+    .from("profiles")
+    .update({
+      is_suspended: false,
+      suspension_reason: null,
+    })
+    .eq("id", userId);
+
+  if (reinstateError) {
+    return NextResponse.json({ error: reinstateError.message }, { status: 500 });
+  }
+
+  logger.info("[AdminSetUserSuspension] Reinstated user", {
+    actor_id: user.id,
+    target_user_id: userId,
+  });
+
+  return NextResponse.json({
+    success: true,
+    message: "User reinstated successfully.",
+  });
+}

--- a/tests/admin/admin-user-lifecycle-guardrail.spec.ts
+++ b/tests/admin/admin-user-lifecycle-guardrail.spec.ts
@@ -30,28 +30,79 @@ async function seedClientWithApplication(runId: number) {
 }
 
 test.describe("Admin user lifecycle guardrails", () => {
-  test("disable endpoint rejects unauthenticated callers", async ({ page }) => {
-    const response = await page.request.post("/api/admin/disable-user", {
-      data: { userId: "00000000-0000-0000-0000-000000000000" },
+  test("set-user-suspension rejects unauthenticated callers", async ({ page }) => {
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: "00000000-0000-0000-0000-000000000000", suspended: true },
     });
     expect(response.status()).toBe(401);
   });
 
-  test("disable endpoint rejects non-client targets", async ({ page }) => {
+  test("set-user-suspension requires suspended boolean", async ({ page }) => {
+    await loginAsAdmin(page);
+    const talentUser = await seedUserWithRole("talent", Date.now());
+
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: talentUser.userId, reason: "missing suspended" },
+    });
+
+    expect(response.status()).toBe(400);
+    const payload = (await response.json()) as { error?: string };
+    expect(payload.error).toMatch(/suspended/i);
+  });
+
+  test("set-user-suspension suspends Talent targets", async ({ page }) => {
+    const runId = Date.now();
+    await loginAsAdmin(page);
+    const talentUser = await seedUserWithRole("talent", runId);
+
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: talentUser.userId, suspended: true, reason: "Guardrail talent suspend" },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .select("is_suspended")
+      .eq("id", talentUser.userId)
+      .maybeSingle();
+
+    if (profileError) {
+      throw new Error(profileError.message);
+    }
+
+    expect(profile?.is_suspended).toBeTruthy();
+  });
+
+  test("legacy disable-user endpoint still suspends when body omits suspended (compat)", async ({
+    page,
+  }) => {
     const runId = Date.now();
     await loginAsAdmin(page);
     const talentUser = await seedUserWithRole("talent", runId);
 
     const response = await page.request.post("/api/admin/disable-user", {
-      data: { userId: talentUser.userId, reason: "Guardrail check" },
+      data: { userId: talentUser.userId, reason: "Legacy compat" },
     });
 
-    expect(response.status()).toBe(400);
-    const payload = (await response.json()) as { error?: string };
-    expect(payload.error).toContain("Career Builder");
+    expect(response.status()).toBe(200);
+
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .select("is_suspended")
+      .eq("id", talentUser.userId)
+      .maybeSingle();
+
+    if (profileError) {
+      throw new Error(profileError.message);
+    }
+
+    expect(profile?.is_suspended).toBeTruthy();
   });
 
-  test("disable endpoint rejects authenticated non-admin callers", async ({ page }) => {
+  test("set-user-suspension rejects authenticated non-admin callers", async ({ page }) => {
     const runId = Date.now();
     const clientUser = await seedUserWithRole("client", runId);
     const nonAdminUser = await seedUserWithRole("talent", runId + 1);
@@ -60,8 +111,8 @@ test.describe("Admin user lifecycle guardrails", () => {
       password: nonAdminUser.password,
     });
 
-    const response = await page.request.post("/api/admin/disable-user", {
-      data: { userId: clientUser.userId, reason: "Forbidden guardrail check" },
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: clientUser.userId, suspended: true, reason: "Forbidden guardrail check" },
     });
 
     expect(response.status()).toBe(403);
@@ -92,6 +143,88 @@ test.describe("Admin user lifecycle guardrails", () => {
     expect(disabledProfile?.is_suspended).toBeTruthy();
   });
 
+  test("set-user-suspension reinstates and clears suspension state", async ({ page }) => {
+    const runId = Date.now();
+    await loginAsAdmin(page);
+    const clientUser = await seedUserWithRole("client", runId);
+
+    const suspendRes = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: clientUser.userId, suspended: true, reason: "To be cleared" },
+    });
+    expect(suspendRes.status()).toBe(200);
+
+    const reinstateRes = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: clientUser.userId, suspended: false },
+    });
+    expect(reinstateRes.status()).toBe(200);
+
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .select("is_suspended, suspension_reason")
+      .eq("id", clientUser.userId)
+      .maybeSingle();
+
+    if (profileError) {
+      throw new Error(profileError.message);
+    }
+
+    expect(profile?.is_suspended).toBeFalsy();
+    expect(profile?.suspension_reason).toBeNull();
+  });
+
+  test("set-user-suspension rejects admin targets", async ({ page }) => {
+    const runId = Date.now();
+    await loginAsAdmin(page);
+    const otherAdmin = await seedUserWithRole("admin", runId);
+
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: otherAdmin.userId, suspended: true },
+    });
+
+    expect(response.status()).toBe(400);
+    const payload = (await response.json()) as { error?: string };
+    expect(payload.error).toMatch(/admin/i);
+  });
+
+  test("set-user-suspension rejects acting on own account", async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const adminEmail = "admin@totlagency.com";
+    let adminUserId: string | undefined;
+    let listPage = 1;
+    const perPage = 1000;
+
+    while (!adminUserId && listPage <= 5) {
+      const { data: usersData, error: listError } = await supabaseAdmin.auth.admin.listUsers({
+        page: listPage,
+        perPage,
+      });
+      if (listError) {
+        throw new Error(listError.message);
+      }
+      adminUserId = usersData?.users?.find(
+        (u) => u.email?.toLowerCase() === adminEmail.toLowerCase()
+      )?.id;
+      if (adminUserId) break;
+      if (!usersData?.users?.length || usersData.users.length < perPage) break;
+      listPage += 1;
+    }
+
+    if (!adminUserId) {
+      throw new Error("Expected admin@totlagency.com in auth user list for self-action guard test");
+    }
+
+    const response = await page.request.post("/api/admin/set-user-suspension", {
+      data: { userId: adminUserId, suspended: true },
+    });
+
+    expect(response.status()).toBe(400);
+    const payload = (await response.json()) as { error?: string };
+    expect(payload.error).toMatch(/own account/i);
+  });
+
   test("hard delete endpoint blocks Career Builder targets with clear guidance", async ({ page }) => {
     const runId = Date.now();
     await loginAsAdmin(page);
@@ -103,7 +236,7 @@ test.describe("Admin user lifecycle guardrails", () => {
 
     expect(response.status()).toBe(409);
     const payload = (await response.json()) as { error?: string };
-    expect(payload.error).toContain("Use Disable Career Builder instead");
+    expect(payload.error).toContain("Use Suspend User instead");
   });
 
   test("hard delete endpoint rejects deleting own admin account", async ({ page }) => {

--- a/tests/admin/admin-users-route.spec.ts
+++ b/tests/admin/admin-users-route.spec.ts
@@ -100,7 +100,7 @@ test.describe("Admin users route contracts", () => {
     const row = page.locator("tr", { hasText: seededClient.displayName }).first();
     await expect(row).toBeVisible();
     await row.getByRole("button").click();
-    await expect(page.getByRole("menuitem", { name: "Disable Career Builder" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Suspend User" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Delete User" })).toHaveCount(0);
     await page.getByRole("menuitem", { name: "View Career Builder Profile" }).click();
 
@@ -154,6 +154,64 @@ test.describe("Admin users route contracts", () => {
     await row.getByRole("button").click();
 
     await expect(page.getByRole("menuitem", { name: "Delete User" })).toHaveCount(0);
+  });
+
+  test("admin rows do not expose Suspend User or Reinstate User", async ({ page }) => {
+    const runId = Date.now();
+    const seededAdmin = await seedUserWithRole("admin", runId);
+
+    await loginAsAdmin(page);
+    await safeGoto(page, "/admin/users");
+
+    await page.getByPlaceholder("Search by name, ID, or role...").fill(seededAdmin.displayName);
+    const row = page.locator("tr", { hasText: seededAdmin.displayName }).first();
+    await expect(row).toBeVisible();
+    await row.getByRole("button").click();
+
+    await expect(page.getByRole("menuitem", { name: "Suspend User" })).toHaveCount(0);
+    await expect(page.getByRole("menuitem", { name: "Reinstate User" })).toHaveCount(0);
+  });
+
+  test("admin can suspend a Talent user and reinstate from Suspended tab", async ({ page }) => {
+    const runId = Date.now();
+    const seededTalent = await seedUserWithRole("talent", runId);
+
+    await loginAsAdmin(page);
+    await safeGoto(page, "/admin/users");
+
+    const searchInput = page.getByPlaceholder("Search by name, ID, or role...");
+    await searchInput.fill(seededTalent.displayName);
+    const row = page.locator("tr", { hasText: seededTalent.displayName }).first();
+    await expect(row).toBeVisible();
+    await row.getByRole("button").click();
+
+    await page.getByRole("menuitem", { name: "Suspend User" }).click();
+    const suspendDialog = page.getByRole("dialog", { name: "Suspend User" });
+    await expect(suspendDialog).toBeVisible();
+    await suspendDialog.getByRole("checkbox", { name: /Confirm suspend/i }).check();
+    await suspendDialog.getByRole("button", { name: "Suspend User" }).click();
+
+    await expect(row).toHaveCount(0, { timeout: 20_000 });
+
+    await page.getByRole("tab", { name: /Suspended \(/i }).first().click();
+    await searchInput.fill(seededTalent.displayName);
+    const suspendedRow = page.locator("tr", { hasText: seededTalent.displayName }).first();
+    await expect(suspendedRow).toBeVisible({ timeout: 20_000 });
+    await suspendedRow.getByRole("button").click();
+    await page.getByRole("menuitem", { name: "Reinstate User" }).click();
+
+    const reinstateDialog = page.getByRole("dialog", { name: "Reinstate User" });
+    await expect(reinstateDialog).toBeVisible();
+    await reinstateDialog.getByRole("checkbox", { name: /Confirm reinstate/i }).check();
+    await reinstateDialog.getByRole("button", { name: "Reinstate User" }).click();
+
+    await expect(suspendedRow).toHaveCount(0, { timeout: 20_000 });
+
+    await page.getByRole("tab", { name: /All \(/i }).first().click();
+    await searchInput.fill(seededTalent.displayName);
+    await expect(page.locator("tr", { hasText: seededTalent.displayName }).first()).toBeVisible({
+      timeout: 20_000,
+    });
   });
 });
 


### PR DESCRIPTION
What broke

Admin `/admin/users` could only suspend Career Builders via the old "Disable Career Builder" flow and had no reinstate action in the dashboard. Talent accounts had no reversible suspend path from this screen. Messaging for blocked Career Builder hard delete still referenced the old disable wording.

Why it broke

`POST /api/admin/disable-user` was intentionally scoped to `profiles.role = client`, and the UI mirrored that contract, while suspension state already lives on `profiles.is_suspended` for middleware and `/suspended`.

What we changed

- Added `lib/api/admin-set-user-suspension.ts` and canonical `POST /api/admin/set-user-suspension` (`{ userId, suspended: boolean, reason? }`) for Talent + Career Builder; blocks self and admin targets; reinstate clears `suspension_reason`.
- `POST /api/admin/disable-user` now delegates to the same handler (omit `suspended` → suspend) for backward compatibility.
- `admin-users-client`: Suspend User / Reinstate User menus and confirmation dialogs; hard delete unchanged (Talent-only).
- `delete-user` 409 copy and troubleshooting docs use neutral "Suspend User" guidance.
- Playwright: `admin-user-lifecycle-guardrail.spec.ts`, `admin-users-route.spec.ts`.
- Docs: `MVP_STATUS_NOTION.md`, `docs/contracts/ADMIN_CONTRACT.md`, `docs/journeys/ADMIN_JOURNEY.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`, `docs/DOCUMENTATION_INDEX.md`.

**Branch note:** Local `develop` was fast-forwarded to `origin/main` before this commit so the PR contains a single commit on top of current `main`.

How we proved it

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass (also exercised by pre-commit hook on commit)
- `npm run lint` — pass (pre-commit)

Docs updated: yes

- `MVP_STATUS_NOTION.md`
- `docs/contracts/ADMIN_CONTRACT.md`
- `docs/journeys/ADMIN_JOURNEY.md`
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`
- `docs/DOCUMENTATION_INDEX.md`

Risk + rollback

Risk level: Med

Rollback plan: Revert commit `1b2044f` and redeploy; `disable-user` remains as a compat entrypoint if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin user-lifecycle behavior and introduces a new canonical suspension API that updates account access state; mistakes could block or restore user access incorrectly despite added guardrails and tests.
> 
> **Overview**
> Adds **reversible suspension management** in the admin users dashboard: `/admin/users` now offers **Suspend User** for active Talent/Career Builder accounts and **Reinstate User** for suspended accounts (admin/self targets blocked), while keeping **Talent-only hard delete** unchanged.
> 
> Introduces canonical `POST /api/admin/set-user-suspension` (and shared `handleAdminSetUserSuspension`) to set `profiles.is_suspended` and optional `suspension_reason`, and updates legacy `POST /api/admin/disable-user` to delegate as a backward-compatible alias.
> 
> Updates Playwright coverage for the new guardrails and UI flows, and aligns docs/error messaging to direct Career Builder hard-delete attempts to **Suspend User** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2044fa00b952d4ca78a6dc3866bf2376c6d4ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->