### PR TITLE
fix(admin): subscription visibility on users list and paid count parity

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,22 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Admin Users — subscription visibility + paid talent count parity (April 17, 2026)**
+
+**ADMIN / UI** — April 17, 2026
+- ✅ **`/admin/users`:** Loads `profiles` subscription + Stripe id fields; **Subscription** column with badges (Paid · plan, Free, Past due, Canceled); non-talent **N/A**; subscription filter chips (All / Paid / Free / Past due / Canceled); talent **Subscription details** dialog (plan, status, billing interval, period end, Stripe IDs when present).
+- ✅ **`/admin/dashboard`:** `paidActiveTalentTotal` = monthly + annual + **unknown-plan** active talent so overview **paid** headcount matches the Users **Paid** filter; desktop card shows active subscriber count + plan breakdown test ids (`paid-talent-count`, `paid-talent-breakdown`); MRR/ARR formulas unchanged (monthly + annual only).
+- ✅ **Tests:** `tests/admin/admin-users-route.spec.ts`, `tests/admin/paid-talent-stats.spec.ts`.
+- ✅ **Docs:** `docs/contracts/ADMIN_CONTRACT.md` (Overview + `/admin/users` parity).
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 17, 2026.
+
+**Next (P0):** Merge **develop → main** via PR; smoke `/admin/users` subscription filters vs dashboard counts on staging.
+
+**Next (P1):** None for this patch.
+
+---
+
 ## 🚀 **Latest: Admin Talent hard delete — FK repair + observability (April 14, 2026)**
 
 **ADMIN / DB / SENTRY** — April 14, 2026

--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,23 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Admin Talent hard delete — FK repair + observability (April 14, 2026)**
+
+**ADMIN / DB / SENTRY** — April 14, 2026
+- ✅ **Root cause (repeatable):** `public.content_flags.assigned_admin_id → profiles(id)` could remain **`NO ACTION`** if the table predated cascade migrations or was only created with `CREATE TABLE IF NOT EXISTS`, blocking `auth.admin.deleteUser` when a flag assigned the **same** talent as `assigned_admin_id`.
+- ✅ **Migration:** `supabase/migrations/20260414120000_repair_fks_for_auth_user_delete.sql` reapplies **`ON DELETE SET NULL`** for `assigned_admin_id`, **`ON DELETE CASCADE`** for `reporter_id`, and defensively reapplies `gig_notifications.user_id → auth.users` **`ON DELETE CASCADE`**.
+- ✅ **API:** `POST /api/admin/delete-user` — structured logs + Sentry context; broader FK-style message matching; generic GoTrue **“Database error deleting user”** returns **409** with suspend guidance (reduces noisy 500s).
+- ✅ **Ops SQL:** `supabase/diagnostics/auth-user-delete-fk-audit.sql` for production FK audits when deletes fail.
+- ✅ **Test:** `tests/admin/admin-user-lifecycle-guardrail.spec.ts` — hard delete with `content_flags` assigning target as `assigned_admin_id`.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint`, `npx playwright test tests/admin/admin-user-lifecycle-guardrail.spec.ts --grep content_flags` — ship run, April 14, 2026.
+
+**Next (P0):** Apply the new migration to **production** (`supabase db push` or pipeline); retry failing deletes; run diagnostic SQL if any remain.
+
+**Next (P1):** None for this patch.
+
+---
+
 ## 🚀 **Latest: Admin Users — reversible suspend / reinstate (April 14, 2026)**
 
 **ADMIN / API / QA** — April 14, 2026

--- a/app/admin/dashboard/admin-dashboard-client.tsx
+++ b/app/admin/dashboard/admin-dashboard-client.tsx
@@ -47,6 +47,7 @@ interface AdminDashboardClientProps {
     monthlyCount: number;
     annualCount: number;
     unknownPlanCount: number;
+    paidActiveTalentTotal: number;
     estimatedMrrCents: number;
     estimatedArrCents: number;
   };
@@ -94,7 +95,7 @@ export function AdminDashboardClient({ user, gigs, applications, paidTalentStats
               { label: "Accepted", value: dashboardStats.acceptedApplications, icon: CheckCircle },
               {
                 label: "Paid talent",
-                value: paidTalentStats.monthlyCount + paidTalentStats.annualCount,
+                value: paidTalentStats.paidActiveTalentTotal,
                 icon: DollarSign,
               },
             ]}
@@ -230,6 +231,14 @@ export function AdminDashboardClient({ user, gigs, applications, paidTalentStats
                 <span data-testid="paid-talent-arr">{money(paidTalentStats.estimatedArrCents)}</span>
                 <span className="text-xs ml-1">/yr</span>
               </div>
+              <p className="text-sm font-medium text-white">
+                <span data-testid="paid-talent-count">{paidTalentStats.paidActiveTalentTotal}</span>
+                <span className="ml-1 font-normal text-[var(--oklch-text-tertiary)]">active subscribers</span>
+              </p>
+              <p className="text-xs text-[var(--oklch-text-tertiary)]" data-testid="paid-talent-breakdown">
+                {paidTalentStats.monthlyCount} monthly · {paidTalentStats.annualCount} annual ·{" "}
+                {paidTalentStats.unknownPlanCount} plan unknown
+              </p>
             </CardContent>
           </Card>
         </div>

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -17,6 +17,8 @@ type PaidTalentStats = {
   monthlyCount: number;
   annualCount: number;
   unknownPlanCount: number;
+  /** Active talent subscribers (monthly + annual + unknown plan); matches admin Users “Paid” filter. */
+  paidActiveTalentTotal: number;
   estimatedMrrCents: number;
   estimatedArrCents: number;
 };
@@ -63,12 +65,17 @@ export default async function AdminDashboard() {
   const ANNUAL_CENTS = 20000; // $200.00
   const annualMrrCents = Math.round(ANNUAL_CENTS / 12); // $16.67/mo equivalent
 
+  const m = monthlyCount ?? 0;
+  const a = annualCount ?? 0;
+  const u = unknownPlanCount ?? 0;
+
   const paidTalentStats: PaidTalentStats = {
-    monthlyCount: monthlyCount ?? 0,
-    annualCount: annualCount ?? 0,
-    unknownPlanCount: unknownPlanCount ?? 0,
-    estimatedMrrCents: (monthlyCount ?? 0) * MONTHLY_CENTS + (annualCount ?? 0) * annualMrrCents,
-    estimatedArrCents: (monthlyCount ?? 0) * (MONTHLY_CENTS * 12) + (annualCount ?? 0) * ANNUAL_CENTS,
+    monthlyCount: m,
+    annualCount: a,
+    unknownPlanCount: u,
+    paidActiveTalentTotal: m + a + u,
+    estimatedMrrCents: m * MONTHLY_CENTS + a * annualMrrCents,
+    estimatedArrCents: m * (MONTHLY_CENTS * 12) + a * ANNUAL_CENTS,
   };
 
   // Fetch dashboard data

--- a/app/admin/users/admin-users-client.tsx
+++ b/app/admin/users/admin-users-client.tsx
@@ -4,7 +4,6 @@ import type { User } from "@supabase/supabase-js";
 import {
   Search,
   MoreVertical,
-  Filter,
   User as UserIcon,
   Shield,
   Briefcase,
@@ -18,6 +17,7 @@ import {
   Trash2,
   AlertCircle,
   Undo2,
+  CreditCard,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -53,7 +53,11 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/use-toast";
 import { getRoleDisplayName } from "@/lib/constants/user-roles";
+import { getPlanDisplayName, getSubscriptionStatusColor, getSubscriptionStatusText } from "@/lib/subscription";
+import { cn } from "@/lib/utils";
 import { logger } from "@/lib/utils/logger";
+
+type SubscriptionFilter = "all" | "paid" | "free" | "past_due" | "canceled";
 
 type UserProfile = {
   id: string;
@@ -65,11 +69,48 @@ type UserProfile = {
   email_verified: boolean | null;
   created_at: string;
   updated_at: string;
+  subscription_status: "none" | "active" | "past_due" | "canceled";
+  subscription_plan: string | null;
+  subscription_current_period_end: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
   talent_profiles?: {
     first_name: string;
     last_name: string;
   } | null;
 };
+
+function talentSubscriptionListLabel(u: UserProfile): string {
+  if (u.subscription_status === "active") {
+    const plan =
+      u.subscription_plan === "monthly"
+        ? "Monthly"
+        : u.subscription_plan === "annual"
+          ? "Annual"
+          : "Plan unset";
+    return `Paid · ${plan}`;
+  }
+  if (u.subscription_status === "none") return "Free";
+  if (u.subscription_status === "past_due") return "Past due";
+  return "Canceled";
+}
+
+function matchesSubscriptionFilter(u: UserProfile, filter: SubscriptionFilter): boolean {
+  if (filter === "all") return true;
+  if (u.role !== "talent") return false;
+  switch (filter) {
+    case "paid":
+      return u.subscription_status === "active";
+    case "free":
+      return u.subscription_status === "none";
+    case "past_due":
+      return u.subscription_status === "past_due";
+    case "canceled":
+      return u.subscription_status === "canceled";
+    default:
+      return true;
+  }
+}
 
 interface AdminUsersClientProps {
   users: UserProfile[];
@@ -86,6 +127,8 @@ export function AdminUsersClient({
   const { toast } = useToast();
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState("all");
+  const [subscriptionFilter, setSubscriptionFilter] = useState<SubscriptionFilter>("all");
+  const [subscriptionDetailUser, setSubscriptionDetailUser] = useState<UserProfile | null>(null);
   const [users, setUsers] = useState(initialUsers);
   const [suspendDialogOpen, setSuspendDialogOpen] = useState(false);
   const [userToSuspend, setUserToSuspend] = useState<UserProfile | null>(null);
@@ -139,6 +182,10 @@ export function AdminUsersClient({
       }
     }
 
+    if (subscriptionFilter !== "all") {
+      filtered = filtered.filter((u) => matchesSubscriptionFilter(u, subscriptionFilter));
+    }
+
     // Filter by search query (within tab's dataset)
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
@@ -155,7 +202,7 @@ export function AdminUsersClient({
     }
 
     return filtered;
-  }, [users, searchQuery, activeTab]);
+  }, [users, searchQuery, activeTab, subscriptionFilter]);
 
   // Group by role for stats (exclude suspended from active tab counts)
   const talentUsers = users.filter((u) => u.role === "talent" && u.is_suspended !== true);
@@ -462,6 +509,33 @@ export function AdminUsersClient({
     </div>
   );
 
+  const renderTalentSubscriptionBadge = (userProfile: UserProfile) => {
+    if (userProfile.role !== "talent") {
+      return (
+        <span
+          className="text-xs text-[var(--oklch-text-tertiary)]"
+          data-testid={`user-subscription-${userProfile.id}`}
+        >
+          N/A
+        </span>
+      );
+    }
+    const label = talentSubscriptionListLabel(userProfile);
+    return (
+      <Badge
+        variant="outline"
+        className={cn(
+          "status-chip max-w-[12rem] truncate border font-medium",
+          getSubscriptionStatusColor(userProfile.subscription_status)
+        )}
+        data-testid={`user-subscription-${userProfile.id}`}
+        title={label}
+      >
+        {label}
+      </Badge>
+    );
+  };
+
   const renderUserActions = (userProfile: UserProfile) => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -479,6 +553,15 @@ export function AdminUsersClient({
               <Eye className="mr-2 h-4 w-4" />
               View Talent Profile
             </Link>
+          </DropdownMenuItem>
+        )}
+        {userProfile.role === "talent" && (
+          <DropdownMenuItem
+            onClick={() => setSubscriptionDetailUser(userProfile)}
+            className="flex items-center text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white"
+          >
+            <CreditCard className="mr-2 h-4 w-4" />
+            Subscription details
           </DropdownMenuItem>
         )}
         {userProfile.role === "client" && (
@@ -579,6 +662,13 @@ export function AdminUsersClient({
                   label: "Email",
                   value: userProfile.email_verified ? "Verified" : "Unverified",
                 },
+                {
+                  label: "Subscription",
+                  value:
+                    userProfile.role === "talent"
+                      ? talentSubscriptionListLabel(userProfile)
+                      : "N/A",
+                },
                 { label: "Joined", value: new Date(userProfile.created_at).toLocaleDateString() },
               ]}
               badge={getCombinedBadges(userProfile.id, userProfile.role, userProfile.is_suspended)}
@@ -595,6 +685,12 @@ export function AdminUsersClient({
                 </th>
                 <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-secondary)]">
                   Role
+                </th>
+                <th
+                  className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-secondary)]"
+                  data-testid="columnheader-subscription"
+                >
+                  Subscription
                 </th>
                 <th className="px-6 py-4 text-left text-xs font-medium uppercase tracking-wider text-[var(--oklch-text-secondary)]">
                   Email Verified
@@ -633,6 +729,7 @@ export function AdminUsersClient({
                       {getSuspensionBadge(userProfile.is_suspended)}
                     </div>
                   </td>
+                  <td className="py-4 px-6">{renderTalentSubscriptionBadge(userProfile)}</td>
                   <td className="py-4 px-6">
                     {userProfile.email_verified ? (
                       <div className="flex items-center gap-2">
@@ -720,24 +817,55 @@ export function AdminUsersClient({
         {/* Users Section */}
         <div className="mb-8 overflow-hidden rounded-2xl panel-frosted card-backlit shadow-lg">
           <div className="border-b border-border/40 bg-gradient-to-r from-card/40 to-card/25 p-4 sm:p-6">
-            <div className="flex flex-col md:flex-row md:items-center justify-between">
-              <h2 className="text-2xl font-bold text-white mb-4 md:mb-0">Users</h2>
-              <div className="flex items-center space-x-3">
-                <div className="relative">
-                  <Search
-                    className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
-                    size={16}
-                  />
-                  <Input
-                    placeholder="Search by name, ID, or role..."
-                    className="w-full pl-9 md:w-64"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                  />
+            <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+              <h2 className="text-2xl font-bold text-white">Users</h2>
+              <div className="flex w-full flex-col gap-3 md:w-auto md:items-end">
+                <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                  <div className="relative w-full sm:w-auto">
+                    <Search
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-[var(--oklch-text-tertiary)]"
+                      size={16}
+                    />
+                    <Input
+                      placeholder="Search by name, ID, or role..."
+                      className="w-full pl-9 sm:w-64"
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                    />
+                  </div>
                 </div>
-                <Button variant="outline" size="icon" className="border-white/10 bg-white/5 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white">
-                  <Filter size={16} />
-                </Button>
+                <div
+                  className="flex flex-wrap gap-1.5 sm:justify-end"
+                  role="group"
+                  aria-label="Filter by subscription"
+                >
+                  {(
+                    [
+                      { id: "all" as const, label: "All" },
+                      { id: "paid" as const, label: "Paid" },
+                      { id: "free" as const, label: "Free" },
+                      { id: "past_due" as const, label: "Past due" },
+                      { id: "canceled" as const, label: "Canceled" },
+                    ] as const
+                  ).map((opt) => (
+                    <Button
+                      key={opt.id}
+                      type="button"
+                      size="sm"
+                      variant={subscriptionFilter === opt.id ? "default" : "outline"}
+                      className={cn(
+                        "h-8 rounded-lg border px-2.5 text-xs",
+                        subscriptionFilter === opt.id
+                          ? "border-orange-500/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30 hover:text-white"
+                          : "border-white/10 bg-white/5 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white"
+                      )}
+                      aria-pressed={subscriptionFilter === opt.id}
+                      onClick={() => setSubscriptionFilter(opt.id)}
+                    >
+                      {opt.label}
+                    </Button>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
@@ -1038,6 +1166,91 @@ export function AdminUsersClient({
                   Delete User
                 </>
               )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={subscriptionDetailUser !== null}
+        onOpenChange={(open) => {
+          if (!open) setSubscriptionDetailUser(null);
+        }}
+      >
+        <DialogContent className="panel-frosted !fixed z-[51] max-h-[85vh] overflow-y-auto border-white/10 bg-[var(--totl-surface-glass-strong)] text-white">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-white">
+              <CreditCard className="h-5 w-5 text-orange-400" />
+              Subscription details
+            </DialogTitle>
+            <DialogDescription className="text-[var(--oklch-text-secondary)]">
+              {subscriptionDetailUser ? (
+                <>
+                  Talent account:{" "}
+                  <span className="font-medium text-white">{getUserDisplayName(subscriptionDetailUser)}</span>
+                </>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+          {subscriptionDetailUser ? (
+            <dl className="space-y-3 text-sm">
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-[var(--oklch-text-tertiary)]">Plan</dt>
+                <dd className="font-medium text-white">{getPlanDisplayName(subscriptionDetailUser.subscription_plan)}</dd>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-[var(--oklch-text-tertiary)]">Status</dt>
+                <dd className="font-medium text-white">
+                  {getSubscriptionStatusText(subscriptionDetailUser.subscription_status)}
+                </dd>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-[var(--oklch-text-tertiary)]">Billing interval</dt>
+                <dd className="font-medium text-white">
+                  {subscriptionDetailUser.subscription_plan === "monthly"
+                    ? "Monthly"
+                    : subscriptionDetailUser.subscription_plan === "annual"
+                      ? "Annual"
+                      : subscriptionDetailUser.subscription_plan
+                        ? subscriptionDetailUser.subscription_plan
+                        : "—"}
+                </dd>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <dt className="text-[var(--oklch-text-tertiary)]">Current period ends</dt>
+                <dd className="font-medium text-white">
+                  {subscriptionDetailUser.subscription_current_period_end ? (
+                    <SafeDate date={subscriptionDetailUser.subscription_current_period_end} />
+                  ) : (
+                    "—"
+                  )}
+                </dd>
+              </div>
+              {subscriptionDetailUser.stripe_customer_id ? (
+                <div className="flex flex-col gap-0.5">
+                  <dt className="text-[var(--oklch-text-tertiary)]">Stripe customer ID</dt>
+                  <dd className="break-all font-mono text-xs text-[var(--oklch-text-secondary)]">
+                    {subscriptionDetailUser.stripe_customer_id}
+                  </dd>
+                </div>
+              ) : null}
+              {subscriptionDetailUser.stripe_subscription_id ? (
+                <div className="flex flex-col gap-0.5">
+                  <dt className="text-[var(--oklch-text-tertiary)]">Stripe subscription ID</dt>
+                  <dd className="break-all font-mono text-xs text-[var(--oklch-text-secondary)]">
+                    {subscriptionDetailUser.stripe_subscription_id}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          ) : null}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setSubscriptionDetailUser(null)}
+              className="border-white/10 bg-white/5 text-[var(--oklch-text-secondary)] hover:bg-white/10 hover:text-white"
+            >
+              Close
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -15,6 +15,11 @@ type UserProfile = {
   email_verified: boolean | null;
   created_at: string;
   updated_at: string;
+  subscription_status: "none" | "active" | "past_due" | "canceled";
+  subscription_plan: string | null;
+  subscription_current_period_end: string | null;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
   talent_profiles?: {
     first_name: string;
     last_name: string;
@@ -32,6 +37,11 @@ const PROFILE_LIST_SELECT = `
   email_verified,
   created_at,
   updated_at,
+  subscription_status,
+  subscription_plan,
+  subscription_current_period_end,
+  stripe_customer_id,
+  stripe_subscription_id,
   talent_profiles!talent_profiles_user_id_fkey(first_name, last_name)
 `;
 

--- a/app/api/admin/delete-user/route.ts
+++ b/app/api/admin/delete-user/route.ts
@@ -1,9 +1,32 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 import { createSupabaseAdminClient } from "@/lib/supabase-admin-client";
 import { logger } from "@/lib/utils/logger";
 
 type SupabaseLikeError = { message?: string; status?: number };
+
+function serializeSupabaseAuthError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const e = error as Error & { status?: number; code?: string };
+    return {
+      name: e.name,
+      message: e.message,
+      status: e.status,
+      code: e.code,
+    };
+  }
+  if (error && typeof error === "object") {
+    const o = error as Record<string, unknown>;
+    return {
+      message: o.message,
+      status: o.status,
+      code: o.code,
+      name: o.name,
+    };
+  }
+  return { message: String(error) };
+}
 
 function isAuthUserNotFoundError(error: SupabaseLikeError): boolean {
   // Supabase Auth admin can return a 404-style error when the user doesn't exist.
@@ -15,7 +38,20 @@ function isAuthUserNotFoundError(error: SupabaseLikeError): boolean {
 
 function isForeignKeyConstraintError(error: SupabaseLikeError): boolean {
   const msg = String(error?.message ?? "");
-  return error?.status === 409 || /foreign key/i.test(msg) || /constraint/i.test(msg);
+  return (
+    error?.status === 409 ||
+    /foreign key/i.test(msg) ||
+    /constraint/i.test(msg) ||
+    /23503/i.test(msg) ||
+    /violates foreign key/i.test(msg) ||
+    /referenced from table/i.test(msg) ||
+    /still referenced/i.test(msg)
+  );
+}
+
+/** GoTrue often wraps Postgres failures as this generic string; treat like a constraint block for UX. */
+function isGenericDatabaseDeletingUserMessage(error: SupabaseLikeError): boolean {
+  return /database error deleting user/i.test(String(error?.message ?? ""));
 }
 
 export const POST = async (request: Request) => {
@@ -191,13 +227,44 @@ export const POST = async (request: Request) => {
           message: "User already deleted.",
         });
       }
-      if (isForeignKeyConstraintError(error as SupabaseLikeError)) {
+
+      const serialized = serializeSupabaseAuthError(error);
+      const constraintLike =
+        isForeignKeyConstraintError(error as SupabaseLikeError) ||
+        isGenericDatabaseDeletingUserMessage(error as SupabaseLikeError);
+
+      logger.error("[AdminDeleteUser] auth.admin.deleteUser failed", {
+        deleted_user_id: userId,
+        deleted_by: user.id,
+        ...serialized,
+      });
+
+      Sentry.withScope((scope) => {
+        scope.setTag("admin_operation", "delete_user");
+        scope.setContext("supabase_auth_admin", {
+          target_user_id: userId,
+          requester_user_id: user.id,
+          error: serialized,
+        });
+        if (constraintLike) {
+          Sentry.captureMessage("Admin delete user blocked (constraint or wrapped DB error)", "warning");
+        } else {
+          Sentry.captureException(
+            error instanceof Error ? error : new Error(String(serialized.message ?? "deleteUser failed"))
+          );
+        }
+      });
+
+      if (constraintLike) {
         return NextResponse.json(
-          { error: "Hard delete failed due to related data constraints. Use Disable instead." },
+          {
+            error:
+              "Hard delete failed due to related data constraints. Use Suspend User instead. If this persists after a schema deploy, check Postgres logs and supabase/diagnostics/auth-user-delete-fk-audit.sql.",
+          },
           { status: 409 }
         );
       }
-      logger.error("Error deleting user:", error);
+
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 14, 2026 (admin Talent **hard delete** FK repair migration + delete-user observability + `supabase/diagnostics/auth-user-delete-fk-audit.sql`; prior: **Suspend User** / **Reinstate User**, `/admin/users` list hardening, mobile drawer / dialog stacking, public gig errors, session-ready probe)
+**Last Updated:** April 17, 2026 (`/admin/users` subscription column + filters + billing dialog; admin dashboard paid-talent headcount parity with unknown-plan bucket; prior: admin Talent **hard delete** FK repair, **Suspend User** / **Reinstate User**, `/admin/users` list hardening, mobile drawer / dialog stacking)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 14, 2026 (admin **Suspend User** / **Reinstate User** + `set-user-suspension` API; prior: `/admin/users` list hardening, mobile drawer / confirmation dialog **`panel-frosted`** stacking, Talent hard delete UI, public gig `PGRST116` vs transport errors, session-ready probe)
+**Last Updated:** April 14, 2026 (admin Talent **hard delete** FK repair migration + delete-user observability + `supabase/diagnostics/auth-user-delete-fk-audit.sql`; prior: **Suspend User** / **Reinstate User**, `/admin/users` list hardening, mobile drawer / dialog stacking, public gig errors, session-ready probe)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 
@@ -46,6 +46,7 @@ All other documentation has been organized into the `docs/` folder with the foll
 | `docs/tests/` | Test documentation and matrices (`tests/README.md`) |
 | `docs/plans/` | Design plans and implementation summaries (`plans/README.md`) |
 | `docs/runbooks/` | Operational runbooks (one-off production procedures, data hygiene) |
+| `supabase/diagnostics/` | **SQL-only** read-only audits for ops (e.g. `auth-user-delete-fk-audit.sql` when `auth.admin.deleteUser` fails) |
 | `docs/archive/` | Historical / superseded documentation (`archive/README.md`) |
 
 **Archive policy:** Historical / one-off reports and superseded plans live in `docs/archive/`. Prefer the non-archived docs unless you are investigating history/regressions.

--- a/docs/contracts/ADMIN_CONTRACT.md
+++ b/docs/contracts/ADMIN_CONTRACT.md
@@ -111,7 +111,7 @@
     - admin role via `profiles.role = 'admin'`
   - Admin user lifecycle guardrails:
     - **Suspend / reinstate:** targets must be `profiles.role` in `('talent','client')`; writes `profiles.is_suspended` and optional `suspension_reason` on suspend; reinstate clears `suspension_reason`. Use **`POST /api/admin/set-user-suspension`** with `{ userId, suspended: boolean, reason? }`. **`POST /api/admin/disable-user`** remains a backward-compatible alias (omit `suspended` → suspend). **Admin** profile targets are rejected (400). **Self** actions rejected (400).
-    - **Hard delete (admin workflow):** target must be `profiles.role = 'talent'`; uses `POST /api/admin/delete-user` (auth user delete + DB cascades)
+    - **Hard delete (admin workflow):** target must be `profiles.role = 'talent'`; uses `POST /api/admin/delete-user` (auth user delete + DB cascades). If production still hits GoTrue **“Database error deleting user”**, verify FKs (especially `content_flags.assigned_admin_id` → **`ON DELETE SET NULL`**) via migration `20260414120000_repair_fks_for_auth_user_delete.sql` and `supabase/diagnostics/auth-user-delete-fk-audit.sql`.
     - admin cannot suspend, reinstate, or hard-delete self
     - admin cannot hard-delete another admin
     - hard delete for Career Builder accounts is blocked (409); **suspend** is the official reversible policy because dependent rows can violate FK constraints on auth user delete
@@ -156,6 +156,11 @@
 3) **Moderation update fails**
 - Symptom: cannot update flags; error indicates permission.
 - Cause: admin not recognized or RLS mismatch.
+
+4) **Talent hard delete fails with generic database error**
+- Symptom: `POST /api/admin/delete-user` returns 500/409 or Sentry shows `AuthApiError: Database error deleting user`.
+- Likely cause: FK still **`NO ACTION`** on a child of `profiles` / `auth.users` (historically `content_flags.assigned_admin_id` when it equals the deleted profile).
+- **Fix:** Apply `20260414120000_repair_fks_for_auth_user_delete.sql`; run `supabase/diagnostics/auth-user-delete-fk-audit.sql` and Postgres logs for `23503`.
 
 ---
 

--- a/docs/contracts/ADMIN_CONTRACT.md
+++ b/docs/contracts/ADMIN_CONTRACT.md
@@ -56,7 +56,8 @@
 - Show **Estimated** MRR/ARR derived from counts (no Stripe API calls):
   - MRR est. = `monthly * $20 + annual * ($200 / 12)` (display $16.67/mo per annual sub)
   - ARR est. = `monthly * $240 + annual * $200`
-- Full breakdown (monthly/annual/unknown counts) may be surfaced on admin talent page or settings; Overview card keeps focus on earnings.
+- **Active subscriber headcount** on the Overview card must equal **`monthly + annual + unknown`** (all active talent), so it matches **`/admin/users`** when filtered to **Paid** (talent + `subscription_status = 'active'`). MRR/ARR intentionally exclude the unknown-plan bucket from dollar estimates.
+- **`/admin/users`:** Subscription status for each row comes from the same `public.profiles` fields (badges + optional **Subscription details** dialog for talent).
 
 **Source of truth:** subscription fields are written by the Stripe webhook into `public.profiles`.
 

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -29,6 +29,10 @@ npm run build
 - **Supabase head count query looks like “zero rows” on failure:** `.select("id", { count: "exact", head: true })` can return **`error`** with **`count: null`**. Using **`result.count ?? 0`** hides outages and wrong-sides UX (e.g. missing “existing applicants” warning).
   - **Fix:** Check **`result.error`**, log it, and choose a **fail-safe** (e.g. assume count > 0 for warnings) or return an error state—not **`?? 0`** alone.
   - **Prevention:** Any **`head: true`** count used for gating or warnings must branch on **`error`** first.
+- **Sentry / Admin: `AuthApiError: Database error deleting user` on `POST /api/admin/delete-user` (TOTLMODELAGENCY-2Z / 3T-style):** GoTrue wraps the underlying Postgres failure; common cause is a **foreign key** blocking cascade when deleting `auth.users` (e.g. `public.content_flags.assigned_admin_id` still **`NO ACTION`** and points at the talent profile being removed).
+  - **Fix:** Apply migration `20260414120000_repair_fks_for_auth_user_delete.sql` (`ON DELETE SET NULL` on `assigned_admin_id`, cascade repairs). Use **`supabase/diagnostics/auth-user-delete-fk-audit.sql`** in the Supabase SQL editor to list FK `delete_rule` to `auth.users` / `profiles(id)`; check Postgres logs for **`23503`** and constraint name.
+  - **API behavior:** Route logs structured details + Sentry context; generic wrapped message maps to **409** with guidance to **Suspend User** if delete still cannot complete.
+  - **Prevention:** Do not rely on `CREATE TABLE IF NOT EXISTS` alone to upgrade FKs; use explicit `ALTER TABLE ... DROP/ADD CONSTRAINT` migrations when delete semantics change.
 - **Admin API routes return 401/403:** `POST /api/admin/create-user`, `GET /api/admin/test-connection`, `GET /api/admin/check-auth-schema` require authenticated admin.
   - **Fix:** Ensure caller is signed in with `profiles.role = 'admin'`. Use `requireAdmin()` from `@/lib/api/require-admin` for new admin routes.
   - **Prevention:** All admin API routes must call `requireAdmin()` (or equivalent) before performing admin operations.

--- a/supabase/diagnostics/auth-user-delete-fk-audit.sql
+++ b/supabase/diagnostics/auth-user-delete-fk-audit.sql
@@ -1,0 +1,54 @@
+-- Run in Supabase SQL Editor (read-only audit) when auth.admin.deleteUser returns
+-- "Database error deleting user" or 23503 in Postgres logs.
+--
+-- 1) Foreign keys referencing auth.users: check DELETE_RULE (CASCADE vs RESTRICT/NO ACTION)
+SELECT
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name,
+  kcu.column_name,
+  ccu.table_schema AS foreign_table_schema,
+  ccu.table_name AS foreign_table_name,
+  ccu.column_name AS foreign_column_name,
+  rc.delete_rule
+FROM information_schema.table_constraints AS tc
+JOIN information_schema.key_column_usage AS kcu
+  ON tc.constraint_name = kcu.constraint_name
+  AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage AS ccu
+  ON ccu.constraint_name = tc.constraint_name
+  AND ccu.table_schema = tc.table_schema
+JOIN information_schema.referential_constraints AS rc
+  ON rc.constraint_name = tc.constraint_name
+  AND rc.constraint_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND ccu.table_schema = 'auth'
+  AND ccu.table_name = 'users'
+ORDER BY tc.table_schema, tc.table_name, tc.constraint_name;
+
+-- 2) Foreign keys referencing public.profiles(id) (sample of delete behavior)
+SELECT
+  tc.table_schema,
+  tc.table_name,
+  tc.constraint_name,
+  kcu.column_name,
+  rc.delete_rule
+FROM information_schema.table_constraints AS tc
+JOIN information_schema.key_column_usage AS kcu
+  ON tc.constraint_name = kcu.constraint_name
+  AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage AS ccu
+  ON ccu.constraint_name = tc.constraint_name
+  AND ccu.table_schema = tc.table_schema
+JOIN information_schema.referential_constraints AS rc
+  ON rc.constraint_name = tc.constraint_name
+  AND rc.constraint_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND ccu.table_schema = 'public'
+  AND ccu.table_name = 'profiles'
+  AND ccu.column_name = 'id'
+ORDER BY tc.table_schema, tc.table_name, tc.constraint_name;
+
+-- 3) Per-user row counts (paste a profiles.id / auth user id)
+-- SELECT count(*) AS content_flags_assigned_admin FROM public.content_flags WHERE assigned_admin_id = 'PASTE_UUID_HERE';
+-- SELECT count(*) AS content_flags_reporter FROM public.content_flags WHERE reporter_id = 'PASTE_UUID_HERE';

--- a/supabase/migrations/20260414120000_repair_fks_for_auth_user_delete.sql
+++ b/supabase/migrations/20260414120000_repair_fks_for_auth_user_delete.sql
@@ -1,0 +1,59 @@
+-- =====================================================
+-- TOTL Agency - Repair FKs that can block auth.users delete
+-- =====================================================
+-- Date (UTC): 2026-04-14
+-- Why:
+--   Admin hard-delete calls auth.admin.deleteUser(), which deletes auth.users and
+--   relies on ON DELETE CASCADE / SET NULL through public.* tables.
+-- Problem:
+--   Environments that created public.content_flags before 2025-12-04, or where
+--   CREATE TABLE IF NOT EXISTS later skipped constraint fixes, may still have
+--   content_flags.assigned_admin_id -> profiles(id) without ON DELETE SET NULL.
+--   Then rows with assigned_admin_id = the deleted talent block the cascade.
+-- Fix:
+--   Idempotently re-apply the intended FK definitions for content_flags and
+--   gig_notifications (defensive; matches 20251204150904_add_cascade_delete_constraints).
+
+BEGIN;
+
+-- content_flags: reporter cascades with profile; assigned admin clears on delete
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'content_flags'
+  ) THEN
+    ALTER TABLE public.content_flags
+      DROP CONSTRAINT IF EXISTS content_flags_reporter_id_fkey;
+    ALTER TABLE public.content_flags
+      ADD CONSTRAINT content_flags_reporter_id_fkey
+        FOREIGN KEY (reporter_id) REFERENCES public.profiles(id) ON DELETE CASCADE;
+
+    ALTER TABLE public.content_flags
+      DROP CONSTRAINT IF EXISTS content_flags_assigned_admin_id_fkey;
+    ALTER TABLE public.content_flags
+      ADD CONSTRAINT content_flags_assigned_admin_id_fkey
+        FOREIGN KEY (assigned_admin_id) REFERENCES public.profiles(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- gig_notifications.user_id -> auth.users (direct)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'gig_notifications'
+  ) THEN
+    ALTER TABLE public.gig_notifications
+      DROP CONSTRAINT IF EXISTS gig_notifications_user_id_fkey;
+    ALTER TABLE public.gig_notifications
+      ADD CONSTRAINT gig_notifications_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+COMMIT;

--- a/tests/admin/admin-user-lifecycle-guardrail.spec.ts
+++ b/tests/admin/admin-user-lifecycle-guardrail.spec.ts
@@ -276,4 +276,42 @@ test.describe("Admin user lifecycle guardrails", () => {
     const payload = (await response.json()) as { error?: string };
     expect(payload.error).toMatch(/own account/i);
   });
+
+  test("hard delete succeeds when content_flags assigns the target talent as assigned_admin", async ({
+    page,
+  }) => {
+    const runId = Date.now();
+    await loginAsAdmin(page);
+    const reporterUser = await seedUserWithRole("talent", runId);
+    const targetUser = await seedUserWithRole("talent", runId + 1);
+
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const { error: flagError } = await supabaseAdmin.from("content_flags").insert({
+      resource_type: "talent_profile",
+      resource_id: targetUser.userId,
+      reporter_id: reporterUser.userId,
+      assigned_admin_id: targetUser.userId,
+      reason: "Guardrail: assigned_admin equals deleted talent profile",
+      status: "open",
+    });
+
+    if (flagError) {
+      throw new Error(flagError.message);
+    }
+
+    const response = await page.request.post("/api/admin/delete-user", {
+      data: { userId: targetUser.userId },
+    });
+
+    expect(response.status()).toBe(200);
+    const payload = (await response.json()) as { success?: boolean };
+    expect(payload.success).toBeTruthy();
+
+    const { data: staleAssigned } = await supabaseAdmin
+      .from("content_flags")
+      .select("id")
+      .eq("assigned_admin_id", targetUser.userId);
+
+    expect(staleAssigned?.length ?? 0).toBe(0);
+  });
 });

--- a/tests/admin/admin-users-route.spec.ts
+++ b/tests/admin/admin-users-route.spec.ts
@@ -116,6 +116,39 @@ test.describe("Admin users route contracts", () => {
     await expect(page.getByRole("heading", { name: "Create New User" }).first()).toBeVisible();
   });
 
+  test("users table shows subscription column and paid talent badge from profile data", async ({ page }) => {
+    const runId = Date.now();
+    const seededTalent = await seedUserWithRole("talent", runId);
+    const supabaseAdmin = createSupabaseAdminClientForTests();
+    const { error: subError } = await supabaseAdmin
+      .from("profiles")
+      .update({
+        subscription_status: "active",
+        subscription_plan: "monthly",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", seededTalent.userId);
+    if (subError) throw new Error(subError.message);
+
+    await loginAsAdmin(page);
+    await safeGoto(page, "/admin/users");
+
+    await expect(page.getByTestId("columnheader-subscription")).toBeVisible();
+    await page.getByPlaceholder("Search by name, ID, or role...").fill(seededTalent.displayName);
+    await expect(page.getByTestId(`user-subscription-${seededTalent.userId}`)).toHaveText("Paid · Monthly");
+  });
+
+  test("non-talent rows show N/A in subscription column", async ({ page }) => {
+    const runId = Date.now();
+    const seededAdmin = await seedUserWithRole("admin", runId);
+
+    await loginAsAdmin(page);
+    await safeGoto(page, "/admin/users");
+
+    await page.getByPlaceholder("Search by name, ID, or role...").fill(seededAdmin.displayName);
+    await expect(page.getByTestId(`user-subscription-${seededAdmin.userId}`)).toHaveText("N/A");
+  });
+
   test("admin can hard-delete an eligible Talent user from actions menu", async ({ page }) => {
     const runId = Date.now();
     const seededTalent = await seedUserWithRole("talent", runId);

--- a/tests/admin/paid-talent-stats.spec.ts
+++ b/tests/admin/paid-talent-stats.spec.ts
@@ -51,6 +51,8 @@ test.describe("Admin Dashboard: Paid Talent stats", () => {
     // Smoke: card renders and contains earning metrics.
     await expect(page.getByTestId("paid-talent-card")).toBeVisible();
     await expect(page.getByTestId("paid-talent-card-title")).toHaveText("Paid Talent");
+    await expect(page.getByTestId("paid-talent-count")).toBeVisible();
+    await expect(page.getByTestId("paid-talent-breakdown")).toBeVisible();
     await expect(page.getByTestId("paid-talent-mrr")).toBeVisible();
     await expect(page.getByTestId("paid-talent-arr")).toBeVisible();
   });


### PR DESCRIPTION
## What broke

Admins could see aggregate **Paid Talent** on the overview but not who was paid in **`/admin/users`**. The mobile overview **Paid talent** count also omitted **active talent with unknown `subscription_plan`**, so it could disagree with the canonical paid-talent definition and with support workflows.

## Why it broke

The admin Users page did not select subscription fields from `public.profiles`, and the dashboard summary used **monthly + annual** only for the mobile headcount instead of **monthly + annual + unknown-plan** active subscribers.

## What we changed

**Latest on `develop` (commit fa21916):**

- Extended admin **`/admin/users`** profile query with subscription + Stripe id columns; added a **Subscription** column, subscription filter chips, and a talent **Subscription details** dialog.
- Aligned admin dashboard **paid active subscriber** total with **`monthlyCount + annualCount + unknownPlanCount`**; desktop card shows count + plan breakdown; MRR/ARR estimates unchanged (still monthly + annual only).
- Playwright coverage for subscription column/badge and paid-talent card test ids; docs: `MVP_STATUS_NOTION.md`, `docs/contracts/ADMIN_CONTRACT.md`, `docs/DOCUMENTATION_INDEX.md`.

**Branch scope honesty:** `develop` is **~285 commits** ahead of `main`. This PR merges the full `develop` line, including prior admin work already on the branch (e.g. suspend/reinstate, users list hardening, talent hard-delete FK repair). The bullets above describe the **newest** shipped change; review the full diff **`main...develop`** for the complete delta.

## How we proved it

Commands run locally (pass):

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass (also run by pre-commit hook on commit)
- `npm run lint` — pass

Playwright: **not** run in this ship session.

**Docs updated:** yes — `MVP_STATUS_NOTION.md`, `docs/contracts/ADMIN_CONTRACT.md`, `docs/DOCUMENTATION_INDEX.md`

---

## Risk + rollback

**Risk level:** Low–Med (admin UI + read-only profile fields; dashboard counts now include unknown-plan actives for headcount only).

**Rollback plan:** Revert commit **fa21916** (or the merge commit on `main` if deployed) and redeploy; no schema migration in this change.
