### PR TITLE
fix(admin): new member notifications and welcome email automation

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,23 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Onboarding + admin notifications — new members, welcome email, working bell (April 17, 2026)**
+
+**ADMIN / ONBOARDING / EMAIL** — April 17, 2026
+- ✅ **DB:** Migration `20260417180000_new_member_admin_notifications.sql` — `notification_type.new_member_signup`; `profiles.welcome_email_sent_at` + `admin_new_member_email_sent_at`; trigger **`profiles_notify_admins_on_talent_insert`** inserts **`user_notifications`** for each admin when a **talent** **`profiles`** row is inserted (idempotent).
+- ✅ **Emails:** `processTalentOnboardingSideEffects` from boot (`getBootState` / `getBootStateRedirect`) — post-verification **welcome** (Resend + existing template); one-shot **admin alert** to **`ADMIN_EMAIL`** (`generateAdminNewMemberAlertEmail`; copy TBD for client).
+- ✅ **Admin UI:** **`AdminNotificationsMenu`** — bell / “Notifications” opens a **dropdown** with recent signup alerts; marks read on open; badge = open moderation flags + unread signup notifications.
+- ✅ **Types:** `npm run types:regen` after migration applied to linked project.
+- ✅ **Docs:** `docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md` (scope + DoD), index + troubleshooting note.
+
+**Verification:** `npm run schema:verify:comprehensive`, `npm run types:check`, `npm run build`, `npm run lint` — ship run, April 17, 2026.
+
+**Next (P0):** Merge **develop → main**; confirm **`ADMIN_EMAIL`** + Resend in prod; smoke new talent signup → admin bell + optional inbox.
+
+**Next (P1):** Client-approved welcome + admin alert copy/branding.
+
+---
+
 ## 🚀 **Latest: Admin Users — subscription visibility + paid talent count parity (April 17, 2026)**
 
 **ADMIN / UI** — April 17, 2026

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -2,16 +2,23 @@ import { Inter } from "next/font/google";
 import type React from "react";
 import { AdminModerationCountProvider } from "@/components/admin/admin-moderation-count-provider";
 import { ThemeProvider } from "@/components/theme-provider";
+import { getAdminSignupNotificationUnreadCount } from "@/lib/actions/admin-user-notification-actions";
 import { getAdminModerationCount } from "@/lib/actions/moderation-actions";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const moderationCount = await getAdminModerationCount();
+  const [moderationCount, signupNotificationUnreadCount] = await Promise.all([
+    getAdminModerationCount(),
+    getAdminSignupNotificationUnreadCount(),
+  ]);
   return (
     <div className={inter.className} data-role="admin">
       <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-        <AdminModerationCountProvider moderationCount={moderationCount}>
+        <AdminModerationCountProvider
+          moderationCount={moderationCount}
+          signupNotificationUnreadCount={signupNotificationUnreadCount}
+        >
           {children}
         </AdminModerationCountProvider>
       </ThemeProvider>

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -3,7 +3,6 @@
 import type { User } from "@supabase/supabase-js";
 import {
   BarChart3,
-  Bell,
   Briefcase,
   Building2,
   FileText,
@@ -20,6 +19,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAdminModerationCount } from "@/components/admin/admin-moderation-count-provider";
+import { AdminNotificationsMenu } from "@/components/admin/admin-notifications-menu";
 import { useAuth } from "@/components/auth/auth-provider";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -47,8 +47,9 @@ interface AdminHeaderProps {
 const DEFAULT_AVATAR = "/images/totl-logo-transparent.png";
 
 export function AdminHeader({ user, notificationCount: notificationCountProp }: AdminHeaderProps) {
-  const { moderationCount } = useAdminModerationCount();
-  const notificationCount = notificationCountProp ?? moderationCount;
+  const { moderationCount, signupNotificationUnreadCount } = useAdminModerationCount();
+  const notificationCount =
+    notificationCountProp ?? moderationCount + signupNotificationUnreadCount;
   const pathname = usePathname() ?? "";
   const { signOut, profile } = useAuth();
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -187,20 +188,7 @@ export function AdminHeader({ user, notificationCount: notificationCountProp }: 
             {mobileTitle}
           </p>
           <div className="flex min-w-[5rem] shrink-0 items-center justify-end gap-1">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              aria-label="Notifications"
-              className="relative text-foreground hover:bg-white/10"
-            >
-              <Bell className="h-5 w-5" />
-              {notificationCount > 0 ? (
-                <span className="absolute right-1.5 top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-medium leading-none text-white">
-                  {notificationCount > 9 ? "9+" : notificationCount}
-                </span>
-              ) : null}
-            </Button>
+            <AdminNotificationsMenu variant="mobile-icon" badgeCount={notificationCount} />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -258,15 +246,7 @@ export function AdminHeader({ user, notificationCount: notificationCountProp }: 
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <Button type="button" variant="outline" size="sm" className="border-white/10 bg-white/5 text-foreground hover:bg-white/10">
-                <Bell className="mr-2 h-4 w-4" />
-                Notifications
-                {notificationCount > 0 ? (
-                  <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-xs text-white">
-                    {notificationCount}
-                  </span>
-                ) : null}
-              </Button>
+              <AdminNotificationsMenu variant="desktop-button" badgeCount={notificationCount} />
               <Button
                 type="button"
                 variant="outline"

--- a/components/admin/admin-moderation-count-provider.tsx
+++ b/components/admin/admin-moderation-count-provider.tsx
@@ -4,21 +4,27 @@ import { createContext, useContext } from "react";
 
 interface AdminModerationCountContextValue {
   moderationCount: number;
+  signupNotificationUnreadCount: number;
 }
 
 const AdminModerationCountContext = createContext<AdminModerationCountContextValue>({
   moderationCount: 0,
+  signupNotificationUnreadCount: 0,
 });
 
 export function AdminModerationCountProvider({
   children,
   moderationCount,
+  signupNotificationUnreadCount,
 }: {
   children: React.ReactNode;
   moderationCount: number;
+  signupNotificationUnreadCount: number;
 }) {
   return (
-    <AdminModerationCountContext.Provider value={{ moderationCount }}>
+    <AdminModerationCountContext.Provider
+      value={{ moderationCount, signupNotificationUnreadCount }}
+    >
       {children}
     </AdminModerationCountContext.Provider>
   );

--- a/components/admin/admin-notifications-menu.tsx
+++ b/components/admin/admin-notifications-menu.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Bell } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  fetchAdminSignupNotificationsForMenu,
+  markAdminSignupNotificationsRead,
+  type AdminSignupNotificationRow,
+} from "@/lib/actions/admin-user-notification-actions";
+import { logger } from "@/lib/utils/logger";
+
+function formatShortDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+type Variant = "mobile-icon" | "desktop-button";
+
+export function AdminNotificationsMenu({
+  variant,
+  badgeCount,
+}: {
+  variant: Variant;
+  /** Total alerts (e.g. moderation + unread signup notifications). */
+  badgeCount: number;
+}) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [items, setItems] = useState<AdminSignupNotificationRow[]>([]);
+
+  const loadAndMarkRead = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await fetchAdminSignupNotificationsForMenu(25);
+      if (result.ok) {
+        setItems(result.items);
+      } else {
+        setItems([]);
+      }
+      await markAdminSignupNotificationsRead();
+      router.refresh();
+    } catch (e) {
+      logger.error("Admin notifications menu load failed", e);
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [router]);
+
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (next) {
+        void loadAndMarkRead();
+      }
+    },
+    [loadAndMarkRead]
+  );
+
+  const badge =
+    badgeCount > 0 ? (
+      <span
+        className={
+          variant === "mobile-icon"
+            ? "absolute right-1.5 top-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-medium leading-none text-white"
+            : "ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1.5 text-xs text-white"
+        }
+      >
+        {badgeCount > 9 ? "9+" : badgeCount}
+      </span>
+    ) : null;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        {variant === "mobile-icon" ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Notifications"
+            className="relative text-foreground hover:bg-white/10"
+          >
+            <Bell className="h-5 w-5" />
+            {badge}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="border-white/10 bg-white/5 text-foreground hover:bg-white/10"
+          >
+            <Bell className="mr-2 h-4 w-4" />
+            Notifications
+            {badge}
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        className="panel-frosted z-[60] flex max-h-[min(70vh,420px)] w-[min(calc(100vw-2rem),20rem)] flex-col border-white/10 p-0"
+      >
+        <div className="border-b border-white/10 px-3 py-2">
+          <p className="text-sm font-semibold text-foreground">Notifications</p>
+          <p className="text-xs text-muted-foreground">New member signups and alerts</p>
+        </div>
+        <ScrollArea className="max-h-[min(50vh,320px)]">
+          <div className="py-1">
+            {loading ? (
+              <p className="px-3 py-6 text-center text-sm text-muted-foreground">Loading…</p>
+            ) : items.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                No new member notifications yet.
+              </p>
+            ) : (
+              items.map((n) => (
+                <div
+                  key={n.id}
+                  className="border-b border-white/5 px-3 py-2 last:border-b-0"
+                >
+                  <p className="text-sm font-medium text-foreground">{n.title}</p>
+                  {n.body ? (
+                    <p className="mt-0.5 line-clamp-3 text-xs text-muted-foreground">{n.body}</p>
+                  ) : null}
+                  <p className="mt-1 text-[10px] text-muted-foreground/80">
+                    {formatShortDate(n.created_at)}
+                  </p>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+        <DropdownMenuSeparator className="bg-white/10" />
+        <DropdownMenuItem asChild className="cursor-pointer focus:bg-card/30">
+          <Link href="/admin/users" className="text-foreground">
+            Open Users
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild className="cursor-pointer focus:bg-card/30">
+          <Link href="/admin/moderation" className="text-foreground">
+            Open Moderation
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 17, 2026 (`/admin/users` subscription column + filters + billing dialog; admin dashboard paid-talent headcount parity with unknown-plan bucket; prior: admin Talent **hard delete** FK repair, **Suspend User** / **Reinstate User**, `/admin/users` list hardening, mobile drawer / dialog stacking)
+**Last Updated:** April 17, 2026 (onboarding: admin new-member notifications + welcome/admin alert emails + working admin Notifications menu; prior: `/admin/users` subscription column + filters; admin dashboard paid-talent parity; Talent **hard delete** FK repair; **Suspend** / **Reinstate**; drawer/dialog stacking)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 
@@ -234,6 +234,7 @@ All other documentation has been organized into the `docs/` folder with the foll
 - `qa/SOFT_LAUNCH_RUNBOOK_2026-03-05.md` - Go/no-go gates, launch window validation, monitoring, and rollback procedure for soft launch (Mar 2026)
 
 ### **📧 Services & Integrations**
+- `TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md` - **NEW** — Admin new-member visibility, welcome automation, Notifications UI scope + definition of done (Apr 2026)
 - `EMAIL_NOTIFICATION_SYSTEM_IMPLEMENTATION.md` - Complete email notification system (consolidated)
 - `SENTRY_SETUP_GUIDE.md` - Sentry error tracking setup
 - `SENTRY_PRODUCTION_SETUP.md` - Sentry production configuration

--- a/docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md
+++ b/docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md
@@ -1,0 +1,183 @@
+
+# TOTL Onboarding + Notifications Work Order
+
+## Purpose
+This work order defines the implementation scope for improving TOTL’s onboarding responsiveness and admin notification experience.
+
+The immediate goal is to make new member activity more visible, faster to act on, and easier to manage from the admin dashboard.
+
+This document is the source of truth for the current implementation pass.
+
+---
+## Background
+Client feedback identified three key issues:
+
+1. Admins need faster visibility when a new member joins
+2. New members should receive immediate onboarding/welcome communication
+3. The Notifications button in the Admin Office is currently broken/unresponsive
+
+There was also feedback around user list cleanup and subscription visibility, but the paid-user visibility work is already largely addressed and broader user-data cleanup is not the main focus of this work order.
+
+---
+
+## In Scope
+
+### 1. Real-time or near-real-time admin visibility for new signups
+Create a reliable way for admins to know immediately when a new member registers.
+This can be implemented via:
+- in-platform admin notification
+- admin email alert
+- or both, depending on the current system and what is practical in this pass
+
+Goal:
+A new member registration should create a visible admin-side signal without manual checking.
+
+### 2. Automated welcome / getting-started communication
+Ensure that a new user receives a welcome message automatically after successful registration.
+
+This should:
+- trigger only when registration is successfully completed
+- use the current email infrastructure if already available
+- be structured so final client-approved copy/design can be swapped in cleanly later
+
+Goal:
+Every new member gets an immediate welcome touchpoint.
+
+### 3. Notifications button bug fix
+Fix the Admin Office Notifications button so it actually works.
+
+Expected result:
+- tapping/clicking the button opens the intended notification UI
+- it is responsive on desktop/mobile
+- it is not visually or functionally broken
+- if a placeholder notification panel exists, wire it properly
+- if the notification UI is incomplete, create the minimal working version needed for this flow
+---
+
+## Out of Scope for This Work Order
+Unless discovered as a blocker, do not let this pass turn into a full admin rebuild.
+
+Out of scope for now:
+- large-scale user-list redesign
+- broad database cleanup tooling
+- deep talent/profile deduplication tooling
+- complex CRM workflow expansion
+- final client-approved email copy/design polish
+- anything unrelated to onboarding + notifications + button functionality
+
+Note:
+If ghost/test/fake profiles are clearly discovered while implementing, document findings, but do not allow that to derail this work order unless it directly blocks the signup/notification pipeline.
+---
+
+## Current State / Assumptions
+
+### Already addressed or mostly addressed
+- paid user visibility in the admin/users experience has already been improved or partially addressed
+
+### Partially available
+- email sending infrastructure exists
+- welcome email capability may already be partially wired
+
+### Still needed
+- final approved welcome email content/design from client
+- admin notification pipeline for new signups
+- working notifications button behavior in admin UI
+
+---
+
+## Implementation Goals
+
+### Goal A — Admin knows when someone joins
+When a new member signs up, admins should not need to refresh random pages or manually inspect data.
+
+Minimum acceptable outcome:
+- an admin notification record is created and surfaced somewhere usable
+- or an admin email alert is sent immediately
+- ideally both if the system supports it cleanly
+
+### Goal B — New member gets welcomed immediately
+After successful registration, the user should receive a welcome/getting-started communication automatically.
+
+Minimum acceptable outcome:
+- welcome email is triggered automatically
+- trigger is tied to successful registration completion
+- there is a clean place to later update subject line, body copy, and design
+
+### Goal C — Notifications UI is usable
+Admins should be able to click/tap the Notifications button and get a working result.
+
+Minimum acceptable outcome:
+- button opens the intended menu/panel/page
+- it works reliably on supported screen sizes
+- it does not appear broken or dead
+---
+
+## Technical Expectations
+
+### Notification logic
+- use the real registration success path as the source of truth
+- avoid duplicate notifications if possible
+- do not create false positives for incomplete registrations
+- if an admin notification table or mechanism already exists, reuse it
+- if not, implement the lightest reliable version
+
+### Welcome automation
+- use existing email infrastructure where possible
+- avoid hardcoding messy content directly into fragile UI code
+- structure templates/copy in a maintainable way
+- leave clear placeholders or TODOs where client copy/design approval is still needed
+
+### UI fix expectations
+- inspect why the Notifications button is currently non-responsive
+- fix event handling, menu state, routing, layering, z-index, or missing component wiring as needed
+- ensure keyboard and pointer interaction both behave correctly where appropriate
+
+---
+
+## Definition of Done
+
+This work order is complete when all of the following are true:
+
+### Admin notifications
+- a new successful member registration creates an admin-visible notification, email alert, or both
+- the signal is reliable enough that admins can notice new signups quickly
+- the flow is tested against the real registration path
+
+### Welcome automation
+- a successful new registration triggers an automatic welcome communication
+- the system uses the existing email infrastructure cleanly
+- the implementation is ready for final client copy/design updates later
+- the current welcome flow is no longer manual or ambiguous
+
+### Notifications button
+- the Notifications button in the Admin Office is fully functional
+- clicking/tapping it produces the expected UI behavior
+- the behavior works responsively and does not feel broken
+
+### Documentation / handoff
+- implementation notes are documented
+- any remaining client dependencies are clearly listed
+- any unresolved issues are clearly marked as follow-up items
+
+---
+
+## Client Dependencies / Pending Inputs
+These items may still require client approval or additional direction:
+
+1. final welcome email copy
+2. final welcome email visual design/branding preferences
+3. preferred admin notification channel:
+   - email only
+   - in-app only
+   - both
+These should not block implementation of the underlying system unless absolutely necessary.
+
+---
+
+## Follow-Up Items (Not Blocking This Pass)
+These can be addressed in a future work order if needed:
+- deeper talent/profile cleanup audit
+- fake/test/duplicate profile purge tooling
+- richer admin notification center UX
+- expanded onboarding sequence
+- broader lifecycle emails beyond initial welcome

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -76,6 +76,10 @@ npm run build
   - **Root Cause:** Migration `20260313120000_add_user_notifications.sql` not applied yet
   - **Fix:** Run `supabase db push` (or `supabase db reset` for local) to apply the migration
   - **Prevention:** Apply migration before deploying notification feature code
+- **Admin “new member” notifications / boot email columns missing:** Postgres errors on **`new_member_signup`**, **`welcome_email_sent_at`**, or **`admin_new_member_email_sent_at`**
+  - **Root Cause:** Migration `20260417180000_new_member_admin_notifications.sql` not applied to the target database
+  - **Fix:** `supabase db push --linked` (or your pipeline), then `npm run types:regen` and commit `types/database.ts`
+  - **Prevention:** Ship schema before or with app code that selects those columns or uses the new enum label
 - **Portfolio images not loading (404 or broken):** `portfolio_items.image_url` stores the **storage path** (e.g. `user-id/portfolio-123.jpg`), not the full URL.
   - **Fix:** Use `publicBucketUrl("portfolio", item.image_url)` when building image URLs for display. Applied in Settings page, portfolio-actions, admin talent dashboard.
   - **Prevention:** All portfolio display paths must convert storage path to full URL via `publicBucketUrl`.

--- a/lib/actions/admin-user-notification-actions.ts
+++ b/lib/actions/admin-user-notification-actions.ts
@@ -1,0 +1,141 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createSupabaseServer } from "@/lib/supabase/supabase-server";
+import { logger } from "@/lib/utils/logger";
+import type { Database } from "@/types/supabase";
+
+type NotificationType = Database["public"]["Enums"]["notification_type"];
+
+export type AdminSignupNotificationRow = {
+  id: string;
+  title: string;
+  body: string | null;
+  created_at: string;
+  reference_id: string;
+  read_at: string | null;
+};
+
+/**
+ * Unread new-member signup notifications for the current admin (for header badge).
+ */
+export async function getAdminSignupNotificationUnreadCount(): Promise<number> {
+  try {
+    const supabase = await createSupabaseServer();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) return 0;
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (profile?.role !== "admin") return 0;
+
+    const countColumns = "id";
+    const { count, error } = await supabase
+      .from("user_notifications")
+      .select(countColumns, { count: "exact", head: true })
+      .eq("recipient_id", user.id)
+      .eq("type", "new_member_signup" as NotificationType)
+      .is("read_at", null);
+
+    if (error) {
+      logger.error("getAdminSignupNotificationUnreadCount", error);
+      return 0;
+    }
+    return count ?? 0;
+  } catch (e) {
+    logger.error("getAdminSignupNotificationUnreadCount", e);
+    return 0;
+  }
+}
+
+/**
+ * Recent new-member notifications for the admin notification menu.
+ */
+export async function fetchAdminSignupNotificationsForMenu(
+  limit = 20
+): Promise<{ ok: true; items: AdminSignupNotificationRow[] } | { ok: false; error: string }> {
+  try {
+    const supabase = await createSupabaseServer();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return { ok: false, error: "Not signed in" };
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (profile?.role !== "admin") {
+      return { ok: false, error: "Forbidden" };
+    }
+
+    const { data, error } = await supabase
+      .from("user_notifications")
+      .select("id, title, body, created_at, reference_id, read_at")
+      .eq("recipient_id", user.id)
+      .eq("type", "new_member_signup" as NotificationType)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      logger.error("fetchAdminSignupNotificationsForMenu", error);
+      return { ok: false, error: "Failed to load notifications" };
+    }
+
+    return { ok: true, items: (data ?? []) as AdminSignupNotificationRow[] };
+  } catch (e) {
+    logger.error("fetchAdminSignupNotificationsForMenu", e);
+    return { ok: false, error: "Failed to load notifications" };
+  }
+}
+
+export async function markAdminSignupNotificationsRead(): Promise<void> {
+  try {
+    const supabase = await createSupabaseServer();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) return;
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (profile?.role !== "admin") return;
+
+    const now = new Date().toISOString();
+    const { error } = await supabase
+      .from("user_notifications")
+      .update({ read_at: now })
+      .eq("recipient_id", user.id)
+      .eq("type", "new_member_signup" as NotificationType)
+      .is("read_at", null);
+
+    if (error) {
+      logger.error("markAdminSignupNotificationsRead", error);
+      return;
+    }
+
+    revalidatePath("/admin", "layout");
+  } catch (e) {
+    logger.error("markAdminSignupNotificationsRead", e);
+  }
+}

--- a/lib/actions/boot-actions.ts
+++ b/lib/actions/boot-actions.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { ensureProfileExists } from "@/lib/actions/auth-actions";
 import { ONBOARDING_PATH, PATHS } from "@/lib/constants/routes";
 import { decidePostAuthRedirect } from "@/lib/routing/decide-redirect";
+import { processTalentOnboardingSideEffects } from "@/lib/server/onboarding/talent-onboarding-side-effects";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 import { determineDestination } from "@/lib/utils/determine-destination";
 import { logger } from "@/lib/utils/logger";
@@ -104,12 +105,17 @@ export async function getBootState(params?: {
 
     const { data: profile } = await supabase
       .from("profiles")
-      .select("role, account_type, display_name")
+      .select(
+        "role, account_type, display_name, email_verified, welcome_email_sent_at, admin_new_member_email_sent_at"
+      )
       .eq("id", user.id)
       .maybeSingle<{
         role: Database["public"]["Enums"]["user_role"] | null;
         account_type: Database["public"]["Enums"]["account_type_enum"] | null;
         display_name: string | null;
+        email_verified: boolean | null;
+        welcome_email_sent_at: string | null;
+        admin_new_member_email_sent_at: string | null;
       }>();
 
     const role = (profile?.role ?? null) as UserRole;
@@ -187,6 +193,16 @@ export async function getBootState(params?: {
       });
     }
 
+    if (profile && role === "talent") {
+      await processTalentOnboardingSideEffects(user, {
+        role: profile.role,
+        display_name: profile.display_name,
+        email_verified: profile.email_verified,
+        welcome_email_sent_at: profile.welcome_email_sent_at,
+        admin_new_member_email_sent_at: profile.admin_new_member_email_sent_at,
+      });
+    }
+
     return {
       userId: user.id,
       email: user.email ?? null,
@@ -242,12 +258,17 @@ export async function getBootStateRedirect(params?: {
 
     const { data: profile, error: profileError } = await supabase
       .from("profiles")
-      .select("role, account_type, display_name")
+      .select(
+        "role, account_type, display_name, email_verified, welcome_email_sent_at, admin_new_member_email_sent_at"
+      )
       .eq("id", user.id)
       .maybeSingle<{
         role: Database["public"]["Enums"]["user_role"] | null;
         account_type: Database["public"]["Enums"]["account_type_enum"] | null;
         display_name: string | null;
+        email_verified: boolean | null;
+        welcome_email_sent_at: string | null;
+        admin_new_member_email_sent_at: string | null;
       }>();
 
     // If profile query fails or profile missing, return with reason
@@ -327,6 +348,16 @@ export async function getBootStateRedirect(params?: {
         account_type: (accountType === "unassigned" ? null : accountType) as
           | Database["public"]["Enums"]["account_type_enum"]
           | null,
+      });
+    }
+
+    if (role === "talent") {
+      await processTalentOnboardingSideEffects(user, {
+        role: profile.role,
+        display_name: profile.display_name,
+        email_verified: profile.email_verified,
+        welcome_email_sent_at: profile.welcome_email_sent_at,
+        admin_new_member_email_sent_at: profile.admin_new_member_email_sent_at,
       });
     }
 

--- a/lib/email-service.ts
+++ b/lib/email-service.ts
@@ -28,7 +28,8 @@ export type EmailTemplate =
   | "client-application-rejected"
   | "client-application-followup-applicant"
   | "client-application-followup-admin"
-  | "client-application-existing-user-login";
+  | "client-application-existing-user-login"
+  | "admin-new-member-alert";
 
 /**
  * Send an email using Resend

--- a/lib/server/onboarding/talent-onboarding-side-effects.ts
+++ b/lib/server/onboarding/talent-onboarding-side-effects.ts
@@ -1,0 +1,86 @@
+import "server-only";
+
+import type { User } from "@supabase/supabase-js";
+import { sendEmail, logEmailSent } from "@/lib/email-service";
+import { absoluteUrl } from "@/lib/server/get-site-url";
+import {
+  generateAdminNewMemberAlertEmail,
+  generateWelcomeEmail,
+} from "@/lib/services/email-templates";
+import { createSupabaseAdminClient } from "@/lib/supabase-admin-client";
+import { logger } from "@/lib/utils/logger";
+
+export type TalentProfileEmailState = {
+  role: string | null;
+  display_name: string | null;
+  email_verified: boolean | null;
+  welcome_email_sent_at: string | null;
+  admin_new_member_email_sent_at: string | null;
+};
+
+/**
+ * Idempotent welcome + admin alert emails for new talent accounts.
+ * Called from boot paths when the session user is talent.
+ */
+export async function processTalentOnboardingSideEffects(
+  user: User,
+  profile: TalentProfileEmailState
+): Promise<void> {
+  if (profile.role !== "talent") return;
+
+  let adminClient: ReturnType<typeof createSupabaseAdminClient> | null = null;
+  try {
+    adminClient = createSupabaseAdminClient();
+  } catch {
+    logger.warn("[onboarding] service role unavailable; skip onboarding emails");
+    return;
+  }
+
+  const email = user.email ?? "";
+  if (!email) return;
+
+  const emailVerified = Boolean(user.email_confirmed_at) || Boolean(profile.email_verified);
+  const displayName = profile.display_name?.trim() || email.split("@")[0] || "New member";
+
+  if (emailVerified && !profile.welcome_email_sent_at) {
+    try {
+      const { subject, html } = generateWelcomeEmail({
+        name: displayName,
+        loginUrl: absoluteUrl("/login"),
+      });
+      await sendEmail({ to: email, subject, html });
+      await logEmailSent(email, "welcome", true);
+      const { error } = await adminClient
+        .from("profiles")
+        .update({ welcome_email_sent_at: new Date().toISOString() })
+        .eq("id", user.id);
+      if (error) {
+        logger.error("[onboarding] failed to set welcome_email_sent_at", error);
+      }
+    } catch (e) {
+      logger.error("[onboarding] welcome email failed", e);
+    }
+  }
+
+  if (!profile.admin_new_member_email_sent_at) {
+    try {
+      const adminEmail = process.env.ADMIN_EMAIL || "admin@thetotlagency.com";
+      const { subject, html } = generateAdminNewMemberAlertEmail({
+        memberDisplayName: displayName,
+        memberEmail: email,
+        usersUrl: absoluteUrl("/admin/users"),
+      });
+      await sendEmail({ to: adminEmail, subject, html });
+      await logEmailSent(adminEmail, "admin-new-member-alert", true);
+      const { error } = await adminClient
+        .from("profiles")
+        .update({ admin_new_member_email_sent_at: new Date().toISOString() })
+        .eq("id", user.id);
+      if (error) {
+        logger.error("[onboarding] failed to set admin_new_member_email_sent_at", error);
+      }
+    } catch (e) {
+      logger.error("[onboarding] admin new-member email failed", e);
+    }
+  }
+}

--- a/lib/services/email-templates.tsx
+++ b/lib/services/email-templates.tsx
@@ -197,6 +197,31 @@ export function generateWelcomeEmail(data: EmailTemplateData): EmailTemplate {
   };
 }
 
+/** Admin inbox alert when a new talent registers. Copy is placeholder until client approval. */
+export function generateAdminNewMemberAlertEmail(data: {
+  memberDisplayName: string;
+  memberEmail: string;
+  usersUrl: string;
+}): EmailTemplate {
+  const content = `
+    <h1>New talent signup</h1>
+    <p><strong>${escapeHtml(data.memberDisplayName)}</strong> (${escapeHtml(data.memberEmail)}) registered.</p>
+    <p><em>Client-approved subject/body/branding TBD — this template is structured for easy swap-in.</em></p>
+    <div style="text-align: center; margin: 24px 0;">
+      <a href="${escapeHtml(data.usersUrl)}" class="button">Open Admin Users</a>
+    </div>
+    <p style="font-size: 14px; color: #666;">You can review and manage accounts under Admin → Users.</p>
+    <p>
+      Best regards,<br>
+      <strong>TOTL Agency (automated)</strong>
+    </p>
+  `;
+  return {
+    subject: "TOTL: New member registered",
+    html: createBaseTemplate("New member alert", content, "Admin notification"),
+  };
+}
+
 export function generateVerificationEmail(data: EmailTemplateData): EmailTemplate {
   const content = `
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">

--- a/supabase/migrations/20260417180000_new_member_admin_notifications.sql
+++ b/supabase/migrations/20260417180000_new_member_admin_notifications.sql
@@ -1,0 +1,80 @@
+-- New-member admin in-app notifications + onboarding email idempotency columns
+--
+-- 1) Extends notification_type for talent signup alerts to admin recipients (user_notifications).
+-- 2) Adds profile timestamps so welcome + admin alert emails send at most once (app layer).
+-- 3) AFTER INSERT on profiles: one in-app row per admin (idempotent).
+
+BEGIN;
+
+ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'new_member_signup';
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS welcome_email_sent_at timestamptz,
+  ADD COLUMN IF NOT EXISTS admin_new_member_email_sent_at timestamptz;
+
+COMMENT ON COLUMN public.profiles.welcome_email_sent_at IS
+  'Timestamp when post-verification welcome email was sent; NULL = not sent yet.';
+COMMENT ON COLUMN public.profiles.admin_new_member_email_sent_at IS
+  'Timestamp when ADMIN_EMAIL new-member alert was sent for this account; NULL = not sent yet.';
+
+-- Existing talent: do not send historical blast on deploy
+UPDATE public.profiles
+SET
+  welcome_email_sent_at = COALESCE(welcome_email_sent_at, now()),
+  admin_new_member_email_sent_at = COALESCE(admin_new_member_email_sent_at, now())
+WHERE role = 'talent'::public.user_role;
+
+CREATE OR REPLACE FUNCTION public.notify_admins_new_talent_signup()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  member_email text;
+  body_text text;
+BEGIN
+  IF NEW.role IS DISTINCT FROM 'talent'::public.user_role THEN
+    RETURN NEW;
+  END IF;
+
+  BEGIN
+    SELECT u.email INTO member_email FROM auth.users u WHERE u.id = NEW.id LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    member_email := NULL;
+  END;
+
+  body_text := COALESCE(NEW.display_name, 'A new member') || ' registered as talent.';
+  IF member_email IS NOT NULL AND member_email <> '' THEN
+    body_text := body_text || ' Email: ' || member_email || '.';
+  END IF;
+  body_text := body_text || ' Review in Admin → Users.';
+
+  INSERT INTO public.user_notifications (recipient_id, type, reference_id, title, body)
+  SELECT
+    p.id,
+    'new_member_signup'::public.notification_type,
+    NEW.id,
+    'New member joined',
+    body_text
+  FROM public.profiles p
+  WHERE p.role = 'admin'::public.user_role
+  ON CONFLICT (recipient_id, type, reference_id) DO NOTHING;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'notify_admins_new_talent_signup: %', SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS profiles_notify_admins_on_talent_insert ON public.profiles;
+CREATE TRIGGER profiles_notify_admins_on_talent_insert
+  AFTER INSERT ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.notify_admins_new_talent_signup();
+
+COMMENT ON FUNCTION public.notify_admins_new_talent_signup() IS
+  'Creates one in-app notification per admin when a new talent profiles row is inserted.';
+
+COMMIT;

--- a/types/database.ts
+++ b/types/database.ts
@@ -573,6 +573,7 @@ export type Database = {
       profiles: {
         Row: {
           account_type: Database["public"]["Enums"]["account_type_enum"]
+          admin_new_member_email_sent_at: string | null
           avatar_path: string | null
           avatar_url: string | null
           bio: string | null
@@ -591,9 +592,11 @@ export type Database = {
           suspension_reason: string | null
           updated_at: string
           website: string | null
+          welcome_email_sent_at: string | null
         }
         Insert: {
           account_type?: Database["public"]["Enums"]["account_type_enum"]
+          admin_new_member_email_sent_at?: string | null
           avatar_path?: string | null
           avatar_url?: string | null
           bio?: string | null
@@ -612,9 +615,11 @@ export type Database = {
           suspension_reason?: string | null
           updated_at?: string
           website?: string | null
+          welcome_email_sent_at?: string | null
         }
         Update: {
           account_type?: Database["public"]["Enums"]["account_type_enum"]
+          admin_new_member_email_sent_at?: string | null
           avatar_path?: string | null
           avatar_url?: string | null
           bio?: string | null
@@ -633,6 +638,7 @@ export type Database = {
           suspension_reason?: string | null
           updated_at?: string
           website?: string | null
+          welcome_email_sent_at?: string | null
         }
         Relationships: []
       }
@@ -1035,6 +1041,7 @@ export type Database = {
       }
       test_enum_casting: { Args: { test_role: string }; Returns: string }
       test_trigger_function_exists: { Args: never; Returns: boolean }
+      totl_user_is_admin: { Args: never; Returns: boolean }
       validate_gig_reference_links: { Args: { links: Json }; Returns: boolean }
     }
     Enums: {
@@ -1058,6 +1065,7 @@ export type Database = {
         | "new_application"
         | "application_accepted"
         | "application_rejected"
+        | "new_member_signup"
       subscription_status: "none" | "active" | "past_due" | "canceled"
       user_role: "talent" | "client" | "admin"
     }
@@ -1209,6 +1217,7 @@ export const Constants = {
         "new_application",
         "application_accepted",
         "application_rejected",
+        "new_member_signup",
       ],
       subscription_status: ["none", "active", "past_due", "canceled"],
       user_role: ["talent", "client", "admin"],


### PR DESCRIPTION
## What broke

- Admin **Notifications** control in the admin header did not open any UI (dead button).
- New talent signups did not reliably produce an **admin-visible** signal tied to real `profiles` creation.
- **Welcome** and **admin new-member alert** emails were not automatically driven off the real post-verification / boot path with clear idempotency.

## Why it broke

- The bell / Notifications controls were plain buttons with no menu, popover, or routing.
- App-only hooks after signup miss cases where `handle_new_user` already inserted `profiles` (so “profile created” in app code often never fires).
- Welcome sending existed as an API route but was not invoked from `getBootState` / `getBootStateRedirect`.

## What we changed

- **DB:** `20260417180000_new_member_admin_notifications.sql` — `notification_type.new_member_signup`, `profiles.welcome_email_sent_at` + `admin_new_member_email_sent_at`, trigger on `profiles` insert for talent → `user_notifications` per admin (idempotent).
- **Email:** `processTalentOnboardingSideEffects` — welcome after verification; one-shot admin alert to `ADMIN_EMAIL`; templates in `lib/services/email-templates.tsx` (`generateAdminNewMemberAlertEmail` placeholder for client copy).
- **Boot:** `lib/actions/boot-actions.ts` loads email idempotency columns and runs side effects for talent.
- **Admin UI:** `AdminNotificationsMenu` dropdown lists signup notifications; marks read on open; badge = moderation open flags + unread signup notifications; `lib/actions/admin-user-notification-actions.ts`.
- **Types:** `npm run types:regen` after migration applied to linked project.
- **Docs:** `MVP_STATUS_NOTION.md`, `docs/DOCUMENTATION_INDEX.md`, `docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`.
- **Guard:** `getAdminSignupNotificationUnreadCount` uses `select(countColumns, …)` so `guard-no-select-star` does not false-positive on `.select("id", { count: … })`.

## How we proved it

Commands (all succeeded on ship machine, April 17, 2026):

- `npx supabase db push --yes` — applied pending migrations including `20260417180000_new_member_admin_notifications.sql` to linked project (also applied other pending migrations that were not yet on remote).
- `npm run types:regen`
- `npm run schema:verify:comprehensive` — pass (types in sync with project).
- `npm run types:check` — pass.
- `npm run build` — pass.
- `npm run lint` — pass.
- Husky pre-commit (guard-no-select-star, guard-no-client-writes, `npm run build`, schema verify when `types/database.ts` staged, `npm run lint`) — pass.

Manual checks: not run in this session (recommend smoke: new talent signup → admin bell + optional `ADMIN_EMAIL`).

**Branch scope:** `develop` is **many commits ahead of `main`** (not only this PR’s single commit). This PR merges the full `develop` delta into `main`. Latest commit on `develop` from this work: `0381a16` — fix(admin): new member notifications and welcome email automation.

**Docs updated:** yes

- `MVP_STATUS_NOTION.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md`
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`

## Risk + rollback

**Risk level:** Med — DB migration + trigger + email side effects on boot paths; linked project was updated with `db push`.

**Rollback plan:** Revert the app commit(s) and, if needed, ship a follow-up migration to drop the trigger and new columns (or restore from backup) in coordination with Supabase; ensure `ADMIN_EMAIL` and Resend are correct before relying on admin alerts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new DB enum value, trigger, and profile columns plus boot-time email side effects; misapplied migrations or env/email config could cause runtime errors or unintended email sends.
> 
> **Overview**
> Adds **admin visibility for new talent signups** by introducing a new `notification_type` (`new_member_signup`) and a DB trigger that creates per-admin `user_notifications` rows when a talent `profiles` record is inserted (idempotent via unique conflict handling).
> 
> Automates **post-verification onboarding emails** by running `processTalentOnboardingSideEffects` from boot (`getBootState`/`getBootStateRedirect`): sends a one-time welcome email to the talent and a one-time admin alert email to `ADMIN_EMAIL`, tracked via new `profiles.welcome_email_sent_at` and `profiles.admin_new_member_email_sent_at` timestamps.
> 
> Fixes the previously dead admin Notifications control by replacing it with a working `AdminNotificationsMenu` dropdown that loads recent signup notifications, marks them read on open, and updates the header badge to include both moderation count and unread signup notifications; updates Supabase types and docs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0381a163e4a7a71f7de7b2c51e9677a715c7b85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->