### PR TITLE
fix(onboarding): prevent duplicate boot welcome emails from race

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -12,7 +12,7 @@
 
 **ADMIN / ONBOARDING / EMAIL** — April 17, 2026
 - ✅ **DB:** Migration `20260417180000_new_member_admin_notifications.sql` — `notification_type.new_member_signup`; `profiles.welcome_email_sent_at` + `admin_new_member_email_sent_at`; trigger **`profiles_notify_admins_on_talent_insert`** inserts **`user_notifications`** for each admin when a **talent** **`profiles`** row is inserted (idempotent).
-- ✅ **Emails:** `processTalentOnboardingSideEffects` from boot (`getBootState` / `getBootStateRedirect`) — post-verification **welcome** (Resend + existing template); one-shot **admin alert** to **`ADMIN_EMAIL`** (`generateAdminNewMemberAlertEmail`; copy TBD for client).
+- ✅ **Emails:** `processTalentOnboardingSideEffects` from boot (`getBootState` / `getBootStateRedirect`) — post-verification **welcome** (Resend + existing template); one-shot **admin alert** to **`ADMIN_EMAIL`** (`generateAdminNewMemberAlertEmail`; copy TBD for client). **Race fix:** conditional DB **claim-then-send** on `welcome_email_sent_at` / `admin_new_member_email_sent_at` (`IS NULL` + `select`) so concurrent boot requests cannot duplicate sends; tests in `lib/server/onboarding/talent-onboarding-side-effects.test.ts`.
 - ✅ **Admin UI:** **`AdminNotificationsMenu`** — bell / “Notifications” opens a **dropdown** with recent signup alerts; marks read on open; badge = open moderation flags + unread signup notifications.
 - ✅ **Types:** `npm run types:regen` after migration applied to linked project.
 - ✅ **Docs:** `docs/TOTL_ONBOARDING_NOTIFICATIONS_WORK_ORDER.md` (scope + DoD), index + troubleshooting note.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** April 17, 2026 (onboarding: admin new-member notifications + welcome/admin alert emails + working admin Notifications menu; prior: `/admin/users` subscription column + filters; admin dashboard paid-talent parity; Talent **hard delete** FK repair; **Suspend** / **Reinstate**; drawer/dialog stacking)
+**Last Updated:** April 17, 2026 (onboarding: claim-then-send for boot emails to prevent duplicate welcome/admin alerts under concurrent boot; admin new-member notifications + welcome/admin alert emails + working admin Notifications menu; prior: `/admin/users` subscription column + filters; admin dashboard paid-talent parity; Talent **hard delete** FK repair; **Suspend** / **Reinstate**; drawer/dialog stacking)
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 

--- a/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
+++ b/docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md
@@ -76,6 +76,9 @@ npm run build
   - **Root Cause:** Migration `20260313120000_add_user_notifications.sql` not applied yet
   - **Fix:** Run `supabase db push` (or `supabase db reset` for local) to apply the migration
   - **Prevention:** Apply migration before deploying notification feature code
+- **Duplicate welcome / admin alert emails for one talent signup:** Two overlapping **`getBootState`** / **`getBootStateRedirect`** invocations could both see **`welcome_email_sent_at`** (or admin timestamp) still **null** and send twice before updating **`profiles`**.
+  - **Fix:** `processTalentOnboardingSideEffects` uses **claim-then-send**: **`UPDATE ... WHERE id = ? AND welcome_email_sent_at IS NULL`** (same for admin column), **`select("id")`**, send only when **exactly one row** is returned.
+  - **Prevention:** Do not send onboarding emails based only on an in-memory profile snapshot; always serialize “first send” via the conditional update (or an equivalent DB RPC).
 - **Admin “new member” notifications / boot email columns missing:** Postgres errors on **`new_member_signup`**, **`welcome_email_sent_at`**, or **`admin_new_member_email_sent_at`**
   - **Root Cause:** Migration `20260417180000_new_member_admin_notifications.sql` not applied to the target database
   - **Fix:** `supabase db push --linked` (or your pipeline), then `npm run types:regen` and commit `types/database.ts`

--- a/lib/server/onboarding/talent-onboarding-side-effects.test.ts
+++ b/lib/server/onboarding/talent-onboarding-side-effects.test.ts
@@ -1,0 +1,177 @@
+import type { User } from "@supabase/supabase-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/supabase-admin-client", () => ({
+  createSupabaseAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/email-service", () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+  logEmailSent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/server/get-site-url", () => ({
+  absoluteUrl: (path: string) => `https://example.test${path}`,
+}));
+
+vi.mock("@/lib/services/email-templates", () => ({
+  generateWelcomeEmail: vi.fn().mockReturnValue({ subject: "Welcome", html: "<p>Hi</p>" }),
+  generateAdminNewMemberAlertEmail: vi.fn().mockReturnValue({
+    subject: "New member",
+    html: "<p>Admin</p>",
+  }),
+}));
+
+vi.mock("@/lib/utils/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { sendEmail } from "@/lib/email-service";
+import { processTalentOnboardingSideEffects } from "@/lib/server/onboarding/talent-onboarding-side-effects";
+import { createSupabaseAdminClient } from "@/lib/supabase-admin-client";
+
+const USER_ID = "00000000-0000-4000-8000-000000000001";
+
+function baseUser(overrides: Partial<User> = {}): User {
+  return {
+    id: USER_ID,
+    aud: "authenticated",
+    role: "authenticated",
+    email: "talent@example.test",
+    email_confirmed_at: new Date().toISOString(),
+    phone: "",
+    confirmed_at: new Date().toISOString(),
+    last_sign_in_at: new Date().toISOString(),
+    app_metadata: {},
+    user_metadata: {},
+    identities: [],
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    is_anonymous: false,
+    ...overrides,
+  } as User;
+}
+
+function createClaimingAdminClient() {
+  let welcomeAt: string | null = null;
+  let adminAt: string | null = null;
+
+  const chain = (kind: "welcome" | "admin") => {
+    return {
+      eq: (_col: string, id: string) => ({
+        is: () => ({
+          select: async () => {
+            if (id !== USER_ID) {
+              return { data: null, error: null };
+            }
+            if (kind === "welcome") {
+              if (welcomeAt !== null) {
+                return { data: [], error: null };
+              }
+              welcomeAt = new Date().toISOString();
+              return { data: [{ id: USER_ID }], error: null };
+            }
+            if (adminAt !== null) {
+              return { data: [], error: null };
+            }
+            adminAt = new Date().toISOString();
+            return { data: [{ id: USER_ID }], error: null };
+          },
+        }),
+      }),
+    };
+  };
+
+  return {
+    from: (table: string) => ({
+      update: (payload: Record<string, unknown>) => {
+        if (table !== "profiles") {
+          return chain("welcome");
+        }
+        if ("welcome_email_sent_at" in payload) {
+          return chain("welcome");
+        }
+        if ("admin_new_member_email_sent_at" in payload) {
+          return chain("admin");
+        }
+        return chain("welcome");
+      },
+    }),
+  };
+}
+
+describe("processTalentOnboardingSideEffects", () => {
+  afterEach(() => {
+    vi.mocked(sendEmail).mockClear();
+    vi.mocked(createSupabaseAdminClient).mockReset();
+  });
+
+  it("sends welcome and admin emails once when claim succeeds", async () => {
+    vi.mocked(createSupabaseAdminClient).mockReturnValue(
+      createClaimingAdminClient() as unknown as ReturnType<typeof createSupabaseAdminClient>
+    );
+
+    await processTalentOnboardingSideEffects(baseUser(), {
+      role: "talent",
+      display_name: "Test Talent",
+      email_verified: true,
+      welcome_email_sent_at: null,
+      admin_new_member_email_sent_at: null,
+    });
+
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends at most one welcome and one admin email under concurrent claims", async () => {
+    vi.mocked(createSupabaseAdminClient).mockReturnValue(
+      createClaimingAdminClient() as unknown as ReturnType<typeof createSupabaseAdminClient>
+    );
+
+    const profile = {
+      role: "talent" as const,
+      display_name: "Test Talent",
+      email_verified: true,
+      welcome_email_sent_at: null,
+      admin_new_member_email_sent_at: null,
+    };
+
+    await Promise.all([
+      processTalentOnboardingSideEffects(baseUser(), profile),
+      processTalentOnboardingSideEffects(baseUser(), profile),
+    ]);
+
+    const welcomeSends = vi.mocked(sendEmail).mock.calls.filter(
+      (c) => c[0].to === "talent@example.test"
+    );
+    const adminSends = vi.mocked(sendEmail).mock.calls.filter(
+      (c) => c[0].to === "admin@thetotlagency.com"
+    );
+    expect(welcomeSends.length).toBe(1);
+    expect(adminSends.length).toBe(1);
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips welcome when profile snapshot already has welcome_email_sent_at", async () => {
+    vi.mocked(createSupabaseAdminClient).mockReturnValue(
+      createClaimingAdminClient() as unknown as ReturnType<typeof createSupabaseAdminClient>
+    );
+
+    await processTalentOnboardingSideEffects(baseUser(), {
+      role: "talent",
+      display_name: "Test",
+      email_verified: true,
+      welcome_email_sent_at: "2020-01-01T00:00:00.000Z",
+      admin_new_member_email_sent_at: null,
+    });
+
+    const welcomeSends = vi.mocked(sendEmail).mock.calls.filter(
+      (c) => c[0].to === "talent@example.test"
+    );
+    expect(welcomeSends.length).toBe(0);
+  });
+});

--- a/lib/server/onboarding/talent-onboarding-side-effects.ts
+++ b/lib/server/onboarding/talent-onboarding-side-effects.ts
@@ -21,6 +21,9 @@ export type TalentProfileEmailState = {
 /**
  * Idempotent welcome + admin alert emails for new talent accounts.
  * Called from boot paths when the session user is talent.
+ *
+ * Uses conditional updates (claim-then-send) so concurrent boot requests cannot
+ * duplicate emails.
  */
 export async function processTalentOnboardingSideEffects(
   user: User,
@@ -44,18 +47,22 @@ export async function processTalentOnboardingSideEffects(
 
   if (emailVerified && !profile.welcome_email_sent_at) {
     try {
-      const { subject, html } = generateWelcomeEmail({
-        name: displayName,
-        loginUrl: absoluteUrl("/login"),
-      });
-      await sendEmail({ to: email, subject, html });
-      await logEmailSent(email, "welcome", true);
-      const { error } = await adminClient
+      const welcomeSentAt = new Date().toISOString();
+      const { data: welcomeClaimRows, error: welcomeClaimError } = await adminClient
         .from("profiles")
-        .update({ welcome_email_sent_at: new Date().toISOString() })
-        .eq("id", user.id);
-      if (error) {
-        logger.error("[onboarding] failed to set welcome_email_sent_at", error);
+        .update({ welcome_email_sent_at: welcomeSentAt })
+        .eq("id", user.id)
+        .is("welcome_email_sent_at", null)
+        .select("id");
+      if (welcomeClaimError) {
+        logger.error("[onboarding] failed to claim welcome_email_sent_at", welcomeClaimError);
+      } else if (welcomeClaimRows?.length === 1) {
+        const { subject, html } = generateWelcomeEmail({
+          name: displayName,
+          loginUrl: absoluteUrl("/login"),
+        });
+        await sendEmail({ to: email, subject, html });
+        await logEmailSent(email, "welcome", true);
       }
     } catch (e) {
       logger.error("[onboarding] welcome email failed", e);
@@ -64,20 +71,27 @@ export async function processTalentOnboardingSideEffects(
 
   if (!profile.admin_new_member_email_sent_at) {
     try {
-      const adminEmail = process.env.ADMIN_EMAIL || "admin@thetotlagency.com";
-      const { subject, html } = generateAdminNewMemberAlertEmail({
-        memberDisplayName: displayName,
-        memberEmail: email,
-        usersUrl: absoluteUrl("/admin/users"),
-      });
-      await sendEmail({ to: adminEmail, subject, html });
-      await logEmailSent(adminEmail, "admin-new-member-alert", true);
-      const { error } = await adminClient
+      const adminSentAt = new Date().toISOString();
+      const { data: adminClaimRows, error: adminClaimError } = await adminClient
         .from("profiles")
-        .update({ admin_new_member_email_sent_at: new Date().toISOString() })
-        .eq("id", user.id);
-      if (error) {
-        logger.error("[onboarding] failed to set admin_new_member_email_sent_at", error);
+        .update({ admin_new_member_email_sent_at: adminSentAt })
+        .eq("id", user.id)
+        .is("admin_new_member_email_sent_at", null)
+        .select("id");
+      if (adminClaimError) {
+        logger.error(
+          "[onboarding] failed to claim admin_new_member_email_sent_at",
+          adminClaimError
+        );
+      } else if (adminClaimRows?.length === 1) {
+        const adminEmail = process.env.ADMIN_EMAIL || "admin@thetotlagency.com";
+        const { subject, html } = generateAdminNewMemberAlertEmail({
+          memberDisplayName: displayName,
+          memberEmail: email,
+          usersUrl: absoluteUrl("/admin/users"),
+        });
+        await sendEmail({ to: adminEmail, subject, html });
+        await logEmailSent(adminEmail, "admin-new-member-alert", true);
       }
     } catch (e) {
       logger.error("[onboarding] admin new-member email failed", e);


### PR DESCRIPTION
## What broke

Concurrent calls to `getBootState()` and `getBootStateRedirect()` could both run `processTalentOnboardingSideEffects` for the same verified talent while `profiles.welcome_email_sent_at` and `profiles.admin_new_member_email_sent_at` were still null, producing **duplicate welcome emails** and **duplicate admin new-member alert emails**.

## Why it broke

The handler used an in-memory profile snapshot (`!profile.welcome_email_sent_at`) and sent email **before** updating the row. The update only filtered on `id`, so two workers could both pass the guard, both call `sendEmail`, and both update the same row—only the emails were duplicated.

## What we changed

- **`lib/server/onboarding/talent-onboarding-side-effects.ts`:** **Claim-then-send** for both timestamps: `UPDATE ... SET ... WHERE id = ? AND <column> IS NULL` with `.select("id")`, then call `sendEmail` / `logEmailSent` only when exactly one row is returned.
- **`lib/server/onboarding/talent-onboarding-side-effects.test.ts`:** Vitest coverage for happy path, concurrent double-invocation (mock DB allows only one claim per column), and skip when snapshot already has `welcome_email_sent_at`.
- **Docs:** `MVP_STATUS_NOTION.md`, `docs/DOCUMENTATION_INDEX.md`, `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`.

**Trade-off:** If the claim succeeds but `sendEmail` fails, the timestamp remains set (no duplicate sends; may need a separate recovery path for a failed provider).

## How we proved it

Commands and outcomes (local, April 17, 2026):

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass (completed after typecheck/lint phase during build)
- `npm run lint` — pass (no warnings after import-order fix in test file)
- `npx vitest run --config vitest.config.ts lib/server/onboarding/talent-onboarding-side-effects.test.ts` — **3 tests passed**

Pre-commit hook on `git commit` re-ran guards + build + lint — **passed**.

## Docs updated: yes

- `MVP_STATUS_NOTION.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/troubleshooting/COMMON_ERRORS_QUICK_REFERENCE.md`

## Scope note

`main...develop` is **one commit** (`55b6462`) at PR open time: this onboarding race fix only.

## Risk + rollback

**Risk level:** Low (narrow change; uses existing nullable columns; service-role path unchanged except filter + ordering).

**Rollback plan:** Revert commit `55b6462` (restore prior send-then-update flow) if unexpected email gaps appear; prefer forward-fix only if rollback would reintroduce duplicate sends.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding email side effects to rely on DB conditional updates; mistakes could suppress welcome/admin emails (especially on provider failures) even though scope is limited to talent boot flows.
> 
> **Overview**
> Prevents duplicate talent onboarding emails under concurrent `getBootState`/`getBootStateRedirect` calls by switching `processTalentOnboardingSideEffects` to a **claim-then-send** flow: conditionally `UPDATE ... IS NULL` + `select` and only send when the row is successfully claimed.
> 
> Adds Vitest coverage for the one-time send behavior (including concurrent invocation) and updates status/docs with troubleshooting guidance for the prior duplicate-email race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b64623193bf6508ed0ab2eb56c7568b740f3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->