### PR TITLE
fix(ui): premium branded loading and editorial hero canopy

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,20 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Premium branded loading + editorial canopy + docs spine (May 2026)**
+
+**UI / PERFORMANCE / DOCUMENTATION**
+- ✅ **Branded loading system:** `TotlBrandLoadingRibbon` / `TotlBrandLoadingRail` / `TotlMarketingLoadingBackdrop` (`components/ui/totl-brand-loading.tsx`), warm veil + rail keyframes in `app/globals.css` (respects reduced motion). **`AuthLoadingShell`** DRYs login/signup/recovery/callback loaders; spinner-only recovery loaders replaced with skeleton + rail where applicable.
+- ✅ **Dashboard + admin loaders:** **`ClientDashboardSkeleton`** / **`TalentDashboardSkeleton`** (with `routeRole`), **`AdminLoadingShell`** ribbon + warm veil strip; **`app/talent/dashboard/client.tsx`** Suspense fallback uses **`TalentDashboardSkeleton`** (no plain “Loading…”).
+- ✅ **Editorial canopy:** **`TotlEditorialSection`** + **`.totl-editorial-canopy`** — CSS-only section hero wash; wired on **`/`** hero, **`/gigs`** headline band, root **`loading.tsx`** parity.
+- ✅ **Docs synced:** `docs/DOCUMENTATION_INDEX.md`, `docs/features/UI_VISUAL_LANGUAGE.md`, `docs/features/README.md`, `docs/UI_IMPLEMENTATION_INDEX.md`, plus this **`MVP_STATUS_NOTION.md`** entry.
+
+**Next (P0):** Staging smoke — cold load `/`, `/login`, `/gigs`, `/client/dashboard`, `/talent/dashboard`, `/admin`; confirm loaders appear instantly; reduced-motion spot check; **`develop` → `main`** PR after CI green.
+
+**Next (P1):** Pending migrations (`20260503171000_*`, `20260504003000_*`) per env; prune temporary schema fallbacks once uniform.
+
+---
+
 ## 🚀 **Latest: Career Builder ship + UX polish pushed to develop (May 4, 2026)**
 
 **SHIPPED THIS RUN** — May 4, 2026

--- a/app/auth/callback/loading.tsx
+++ b/app/auth/callback/loading.tsx
@@ -1,16 +1,12 @@
-import { PageShell } from "@/components/layout/page-shell";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
 import { SectionCard } from "@/components/layout/section-card";
 import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export default function AuthCallbackLoading() {
   return (
-    <PageShell fullBleed className="grain-texture glow-backplate relative overflow-x-hidden text-white">
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-
-      <div className="relative z-10 flex min-h-[60vh] items-center justify-center p-4">
+    <AuthLoadingShell ribbonFootline="Verifying credentials…">
+      <div className="flex min-h-[52vh] items-center justify-center p-4 pt-2">
         <SectionCard className="w-full max-w-md" paddingClassName="p-6 sm:p-8">
           <CardHeader className="p-0 pb-4">
             <CardTitle className="text-center text-white">Email Verification</CardTitle>
@@ -24,6 +20,6 @@ export default function AuthCallbackLoading() {
           </div>
         </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/app/client/signup/loading.tsx
+++ b/app/client/signup/loading.tsx
@@ -1,33 +1,30 @@
-import { PageShell } from "@/components/layout/page-shell";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
 import { SectionCard } from "@/components/layout/section-card";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function ClientSignupLoading() {
   return (
-    <PageShell fullBleed className="grain-texture glow-backplate relative overflow-x-hidden text-white">
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-
-      <div className="relative z-10 container mx-auto px-4 py-8 sm:py-12 lg:px-8">
+    <AuthLoadingShell ribbonFootline="Loading application…">
+      <div className="container mx-auto px-4 pb-12 pt-1 sm:px-6 lg:px-8">
         <div className="mb-8 h-4 w-16 animate-pulse rounded bg-white/10" />
 
         <SectionCard className="mx-auto max-w-md overflow-hidden" paddingClassName="p-6 sm:p-8">
           <div className="space-y-6">
             <div className="space-y-2">
               <div className="mx-auto h-16 w-16 animate-pulse rounded-full bg-white/10" />
-              <div className="mx-auto h-6 w-4/5 animate-pulse rounded bg-white/10" />
+              <div className="mx-auto h-6 max-w-[90%] animate-pulse rounded bg-white/10" />
               <div className="mx-auto h-4 w-full animate-pulse rounded bg-white/10" />
             </div>
             <div className="h-20 animate-pulse rounded-lg bg-white/10" />
             <div className="space-y-3">
-              <div className="h-4 w-full animate-pulse rounded bg-white/10" />
-              <div className="h-4 w-5/6 animate-pulse rounded bg-white/10" />
+              <Skeleton className="h-4 w-full bg-white/10" />
+              <Skeleton className="h-4 w-[83%] bg-white/10" />
             </div>
-            <div className="h-10 w-full animate-pulse rounded bg-white/10" />
-            <div className="h-10 w-full animate-pulse rounded bg-white/10" />
+            <Skeleton className="h-10 w-full bg-white/10" />
+            <Skeleton className="h-10 w-full bg-white/10" />
           </div>
         </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,29 +1,38 @@
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
 
 export default function DashboardLoading() {
   return (
-    <div className="min-h-screen bg-black page-ambient">
-      <div className="container mx-auto py-10 px-4">
-        <Skeleton className="h-10 w-48 mb-8 bg-white/10" />
+    <TotlAtmosphereShell className="grain-texture min-h-[100dvh] text-[var(--oklch-text-primary)]">
+      <div className="container mx-auto px-4 py-10 pb-14 sm:px-6 lg:px-8">
+        <TotlBrandLoadingRibbon
+          compact
+          eyebrow="TOTL Dashboard"
+          footline="Selecting your lane…"
+          className="mb-8 max-w-xl"
+        />
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Skeleton className="mb-8 h-10 w-48 rounded-xl bg-muted/40" />
+
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
           <div className="md:col-span-1">
-            <Card>
+            <Card className="border-border/45 bg-card/40">
               <CardHeader>
-                <Skeleton className="h-6 w-36 mb-2 bg-white/10" />
-                <Skeleton className="h-4 w-48 bg-white/10" />
+                <Skeleton className="mb-2 h-6 w-36 rounded-lg bg-muted/40" />
+                <Skeleton className="h-4 w-48 rounded-lg bg-muted/35" />
               </CardHeader>
               <CardContent>
                 <div className="space-y-4">
                   {[1, 2, 3, 4].map((i) => (
                     <div key={i}>
-                      <Skeleton className="h-4 w-24 mb-2 bg-white/10" />
-                      <Skeleton className="h-6 w-full bg-white/10" />
+                      <Skeleton className="mb-2 h-4 w-24 rounded-lg bg-muted/35" />
+                      <Skeleton className="h-6 w-full rounded-lg bg-muted/40" />
                     </div>
                   ))}
                   <div className="pt-4">
-                    <Skeleton className="h-10 w-full bg-white/10" />
+                    <Skeleton className="h-10 w-full rounded-lg bg-muted/40" />
                   </div>
                 </div>
               </CardContent>
@@ -31,17 +40,17 @@ export default function DashboardLoading() {
           </div>
 
           <div className="md:col-span-2">
-            <Card>
+            <Card className="border-border/45 bg-card/40">
               <CardHeader>
-                <Skeleton className="h-6 w-48 mb-2 bg-white/10" />
-                <Skeleton className="h-4 w-64 bg-white/10" />
+                <Skeleton className="mb-2 h-6 w-48 rounded-lg bg-muted/40" />
+                <Skeleton className="h-4 w-64 rounded-lg bg-muted/35" />
               </CardHeader>
               <CardContent>
                 <div className="space-y-6">
-                  <Skeleton className="h-5 w-36 mb-4 bg-white/10" />
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <Skeleton className="h-10 w-full bg-white/10" />
-                    <Skeleton className="h-10 w-full bg-white/10" />
+                  <Skeleton className="mb-4 h-5 w-36 rounded-lg bg-muted/40" />
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <Skeleton className="h-10 w-full rounded-lg bg-muted/40" />
+                    <Skeleton className="h-10 w-full rounded-lg bg-muted/35" />
                   </div>
                 </div>
               </CardContent>
@@ -49,6 +58,6 @@ export default function DashboardLoading() {
           </div>
         </div>
       </div>
-    </div>
+    </TotlAtmosphereShell>
   );
 }

--- a/app/gigs/[id]/loading.tsx
+++ b/app/gigs/[id]/loading.tsx
@@ -1,10 +1,18 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
 
 export default function GigDetailLoading() {
   return (
     <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient pt-40">
       <div className="container mx-auto px-4 py-8">
         <div className="mx-auto max-w-4xl space-y-6">
+          <TotlBrandLoadingRibbon
+            compact
+            eyebrow="Opportunity"
+            footline="Loading brief…"
+            className="max-w-lg"
+          />
+
           {/* Back link skeleton */}
           <Skeleton className="h-5 w-24" />
 

--- a/app/gigs/loading.tsx
+++ b/app/gigs/loading.tsx
@@ -1,11 +1,21 @@
 import { GigCardSkeleton } from "@/components/ui/image-skeletons";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
 
 export default function Loading() {
   return (
     <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient pt-40">
       <div className="container mx-auto px-4 py-10 sm:py-12">
         <div className="mx-auto max-w-6xl">
+          <div className="mb-8 px-2 sm:px-0">
+            <TotlBrandLoadingRibbon
+              compact
+              eyebrow="Opportunities"
+              footline="Indexing opportunities…"
+              className="max-w-xl"
+            />
+          </div>
+
           {/* Breadcrumb skeleton */}
           <div className="mb-6 flex items-center gap-3 px-2 sm:mb-8 sm:px-0">
             <Skeleton className="h-4 w-16" />

--- a/app/gigs/page.tsx
+++ b/app/gigs/page.tsx
@@ -12,6 +12,7 @@ import { SavedSearchesBar } from "@/components/gigs/saved-searches-bar";
 import { PageShell } from "@/components/layout/page-shell";
 import { SubscriptionPrompt } from "@/components/subscription-prompt";
 import { Button } from "@/components/ui/button";
+import { TotlEditorialSection } from "@/components/ui/totl-editorial-section";
 import { getCategoryFilterSet } from "@/lib/constants/gig-categories";
 import { GIGS_SORT_OPTIONS, type GigsSortValue } from "@/lib/constants/gigs-sort";
 import { getPayRangeBounds, type PayRangeValue } from "@/lib/constants/pay-range-filter";
@@ -394,7 +395,7 @@ export default async function GigsPage({
             </div>
           </div>
 
-          <div className="mb-6 sm:mb-10 text-left md:text-center px-4 sm:px-0">
+          <TotlEditorialSection className="relative mb-8 sm:mb-11 px-4 pb-8 text-left sm:px-0 sm:pb-10 md:text-center">
             <div className="panel-frosted w-fit mx-0 md:mx-auto mb-4 sm:mb-6 px-4 sm:px-6 py-2 sm:py-3">
               <span className="text-white font-medium text-xs sm:text-sm">Active Opportunities</span>
             </div>
@@ -405,7 +406,7 @@ export default async function GigsPage({
               Browse available opportunities and filter by opportunity type, location, and compensation
               to find the right fit for your next booking.
             </p>
-          </div>
+          </TotlEditorialSection>
 
           {/* Subscription Prompt for talent users */}
           {shouldShowSubscriptionPrompt(profile) && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -948,6 +948,87 @@
   }
 }
 
+/* Brand loading: indeterminate rail + warm veil (see components/ui/totl-brand-loading.tsx) */
+@keyframes totl-loading-rail-shift {
+  0% {
+    transform: translateX(-100%);
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.95;
+  }
+  100% {
+    transform: translateX(320%);
+    opacity: 0.45;
+  }
+}
+
+.totl-brand-loading-rail__bar {
+  width: 42%;
+  background: linear-gradient(
+    90deg,
+    rgba(251, 191, 129, 0.28),
+    rgba(196, 181, 253, 0.95),
+    rgba(253, 230, 138, 0.32)
+  );
+  animation: totl-loading-rail-shift 2.1s ease-in-out infinite;
+}
+
+.totl-brand-loading-warm-veil {
+  opacity: 0.82;
+  background:
+    radial-gradient(ellipse 80% 52% at 50% -8%, rgba(251, 191, 129, 0.09), transparent 58%),
+    radial-gradient(ellipse 55% 40% at 86% 18%, rgba(167, 139, 250, 0.08), transparent 55%),
+    radial-gradient(ellipse 60% 45% at 10% 22%, rgba(148, 197, 255, 0.055), transparent 52%);
+}
+
+/**
+ * Editorial hero canopy — section-sized wash (pairs with TotlEditorialSection).
+ * Stays inside overflow-hidden ancestors; opacity-only drift when motion OK.
+ */
+.totl-editorial-canopy {
+  position: relative;
+  isolation: isolate;
+}
+
+.totl-editorial-canopy > * {
+  position: relative;
+  z-index: 1;
+}
+
+.totl-editorial-canopy::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  inset: 0 auto auto 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: min(28rem, 58%);
+  max-height: min(480px, 70vh);
+  pointer-events: none;
+  opacity: 0.5;
+  background:
+    radial-gradient(ellipse 88% 100% at 50% -2%, rgba(255, 255, 255, 0.07), transparent 56%),
+    radial-gradient(ellipse 52% 70% at 10% 0%, rgba(186, 167, 255, 0.08), transparent 54%),
+    radial-gradient(ellipse 48% 65% at 92% -4%, rgba(253, 230, 138, 0.042), transparent 52%);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .totl-editorial-canopy::before {
+    animation: totl-editorial-canopy-breathe 15s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes totl-editorial-canopy-breathe {
+  0% {
+    opacity: 0.42;
+  }
+  100% {
+    opacity: 0.64;
+  }
+}
+
 .animate-fade-in-up {
   animation: fadeInUp 0.6s ease-out;
 }
@@ -2010,7 +2091,18 @@ label {
   .animate-checkmark {
     animation: none !important;
   }
-  
+
+  .totl-brand-loading-rail__bar {
+    animation: none !important;
+    transform: translateX(70%);
+    opacity: 0.88;
+  }
+
+  .totl-editorial-canopy::before {
+    animation: none !important;
+    opacity: 0.52;
+  }
+
   /* Keep functional transitions only */
   .hover-transition,
   .hover-scale,

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,23 +1,71 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRibbon, TotlMarketingLoadingBackdrop } from "@/components/ui/totl-brand-loading";
 
+/** Root segment loader: matches homepage hero structure (marketing grid + branded ribbon). */
 export default function RootLoading() {
   return (
-    <div className="min-h-screen bg-[var(--oklch-bg)] page-ambient">
-      <div className="container mx-auto px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
-        <div className="mx-auto max-w-6xl space-y-8">
-          <div className="space-y-3">
-            <Skeleton className="h-10 w-56 rounded-xl" />
-            <Skeleton className="h-5 w-80 max-w-full rounded-xl" />
+    <TotlMarketingLoadingBackdrop>
+      <main className="relative flex-1">
+        <section className="totl-editorial-canopy relative overflow-hidden pb-14 pt-24 sm:pt-28 lg:pt-32">
+          <div className="container mx-auto px-4 pb-14 sm:px-6 lg:px-8 lg:pb-20">
+            <div className="mb-10 lg:mb-14">
+              <TotlBrandLoadingRibbon
+                eyebrow="TOTL Agency"
+                footline="Calibrating the experience…"
+                className="max-w-xl"
+              />
+            </div>
+
+            <div className="grid items-start gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)] lg:gap-16 lg:items-center">
+              <div className="max-w-2xl space-y-8">
+                <Skeleton className="inline-flex h-10 max-w-[19rem] rounded-full bg-white/10" />
+
+                <div className="space-y-5">
+                  <Skeleton className="h-14 max-w-xl rounded-xl bg-white/12 sm:h-[3.75rem] lg:h-16 lg:max-w-2xl" />
+                  <Skeleton className="h-14 max-w-xl rounded-xl bg-white/10 sm:h-[3.5rem] lg:h-[3.75rem]" />
+                  <Skeleton className="h-5 max-w-xl rounded-xl bg-white/8 sm:h-6" />
+                  <Skeleton className="hidden h-5 max-w-[22rem] rounded-xl bg-white/8 sm:block sm:h-6" />
+                </div>
+
+                <div className="flex flex-wrap gap-3 pt-2">
+                  <Skeleton className="h-11 w-[8.5rem] rounded-xl bg-white/10 sm:h-12 sm:w-[9.25rem]" />
+                  <Skeleton className="h-11 w-[7rem] rounded-xl bg-white/8 sm:h-12 sm:w-[8rem]" />
+                </div>
+              </div>
+
+              <div className="relative min-h-[380px] w-full lg:min-h-[420px]">
+                <div className="panel-frosted grain-texture relative mx-auto overflow-hidden rounded-3xl border border-white/12 p-5 shadow-xl sm:p-7">
+                  <div className="mb-5 flex items-center gap-3">
+                    <Skeleton className="h-11 w-11 shrink-0 rounded-2xl bg-white/15" />
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <Skeleton className="h-4 w-[45%] max-w-[10rem] rounded-lg bg-white/12" />
+                      <Skeleton className="h-3 w-[70%] max-w-[14rem] rounded-lg bg-white/8" />
+                    </div>
+                  </div>
+
+                  <div className="space-y-4">
+                    <Skeleton className="aspect-[16/11] w-full rounded-2xl bg-white/8" />
+
+                    <div className="grid grid-cols-2 gap-3 sm:gap-4">
+                      <Skeleton className="h-16 rounded-xl bg-white/8 sm:h-[4.75rem]" />
+                      <Skeleton className="h-16 rounded-xl bg-white/10 sm:h-[4.75rem]" />
+                      <Skeleton className="col-span-2 h-24 rounded-xl bg-white/10" />
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 pt-1">
+                      <Skeleton className="h-7 w-[4.75rem] rounded-full bg-white/12" />
+                      <Skeleton className="h-7 w-[6rem] rounded-full bg-white/8" />
+                      <Skeleton className="h-7 w-[7.25rem] rounded-full bg-white/8" />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="pointer-events-none absolute -right-12 top-24 hidden h-48 w-48 rounded-full bg-violet-500/10 blur-[64px] lg:block" aria-hidden />
+              </div>
+            </div>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <Skeleton className="h-64 rounded-2xl" />
-            <Skeleton className="h-64 rounded-2xl" />
-            <Skeleton className="h-64 rounded-2xl" />
-          </div>
-          <Skeleton className="h-96 rounded-2xl" />
-        </div>
-      </div>
-    </div>
+        </section>
+      </main>
+    </TotlMarketingLoadingBackdrop>
   );
 }
-

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,14 +1,10 @@
-import { PageShell } from "@/components/layout/page-shell";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
 import { SectionCard } from "@/components/layout/section-card";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
 
 export default function LoginLoading() {
   return (
-    <PageShell fullBleed className="grain-texture glow-backplate relative overflow-x-hidden text-white">
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-
-      <div className="relative z-10 container mx-auto px-4 py-4 sm:px-6 sm:py-6 md:py-8 lg:px-8">
+    <AuthLoadingShell ribbonFootline="Opening sign in…">
+      <div className="container mx-auto px-4 pb-10 pt-1 sm:px-6 md:pb-12 lg:px-8">
         <div className="mb-4 h-4 w-28 animate-pulse rounded bg-white/10 sm:mb-6 md:mb-6" />
 
         <SectionCard className="mx-auto max-w-md overflow-hidden" paddingClassName="p-4 sm:p-6 md:p-8">
@@ -32,6 +28,6 @@ export default function LoginLoading() {
           </div>
         </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/app/reset-password/loading.tsx
+++ b/app/reset-password/loading.tsx
@@ -1,18 +1,27 @@
-import { PageShell } from "@/components/layout/page-shell";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
+import { SectionCard } from "@/components/layout/section-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRail } from "@/components/ui/totl-brand-loading";
 
 export default function ResetPasswordLoading() {
   return (
-    <PageShell
-      fullBleed
-      className="grain-texture glow-backplate relative overflow-x-hidden text-white"
-    >
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-      <div className="relative z-10 flex min-h-[60vh] items-center justify-center px-4">
-        <LoadingSpinner size="lg" className="text-white" />
+    <AuthLoadingShell ribbonFootline="Preparing recovery…">
+      <div className="flex min-h-[52vh] items-center justify-center px-4 pb-16 pt-2">
+        <SectionCard className="w-full max-w-md overflow-hidden" paddingClassName="p-6 sm:p-8">
+          <div className="space-y-5">
+            <div className="space-y-1 text-center">
+              <Skeleton className="mx-auto h-7 w-48 rounded-lg bg-white/10" />
+              <Skeleton className="mx-auto h-4 w-64 max-w-full rounded-lg bg-white/10" />
+            </div>
+            <TotlBrandLoadingRail className="opacity-95" />
+            <div className="space-y-3 pt-2">
+              <Skeleton className="h-10 w-full rounded-lg bg-white/10" />
+              <Skeleton className="h-10 w-full rounded-lg bg-white/10" />
+              <Skeleton className="mx-auto h-4 w-40 rounded-lg bg-white/10" />
+            </div>
+          </div>
+        </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/app/talent/dashboard/client.tsx
+++ b/app/talent/dashboard/client.tsx
@@ -26,6 +26,7 @@ import { useState, useEffect, useCallback, Suspense, useRef } from "react";
 import { ApplicationDetailsModal } from "@/components/application-details-modal";
 import { useAuth } from "@/components/auth/auth-provider";
 import { MobileSummaryRow } from "@/components/dashboard/mobile-summary-row";
+import { TalentDashboardSkeleton } from "@/components/dashboard/talent-dashboard-skeleton";
 import { GigCard } from "@/components/gigs/gig-card";
 import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
 import { PageHeader } from "@/components/layout/page-header";
@@ -1779,13 +1780,7 @@ export function DashboardClient({
   disableClientFetch?: boolean;
 }) {
   return (
-    <Suspense
-      fallback={
-        <PageShell className="grain-texture glow-backplate text-white" containerClassName="flex min-h-[70vh] items-center justify-center py-8">
-          <p className="text-xl text-[var(--oklch-text-primary)]">Loading...</p>
-        </PageShell>
-      }
-    >
+    <Suspense fallback={<TalentDashboardSkeleton />}>
       <TalentDashboardContent initialData={initialData} disableClientFetch={disableClientFetch} />
     </Suspense>
   );

--- a/app/talent/dashboard/loading.tsx
+++ b/app/talent/dashboard/loading.tsx
@@ -1,33 +1,5 @@
-import { PageShell } from "@/components/layout/page-shell";
-import { Skeleton } from "@/components/ui/skeleton";
+import { TalentDashboardSkeleton } from "@/components/dashboard/talent-dashboard-skeleton";
 
 export default function TalentDashboardLoading() {
-  return (
-    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
-      <div className="px-4 py-8">
-        <div className="mx-auto w-full max-w-6xl space-y-8">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-4">
-              <Skeleton className="h-12 w-12 shrink-0 rounded-full bg-muted/40" />
-              <div className="space-y-2">
-                <Skeleton className="h-7 w-56 rounded-lg bg-muted/40" />
-                <Skeleton className="h-4 w-72 max-w-full rounded-lg bg-muted/35" />
-              </div>
-            </div>
-            <div className="flex gap-2">
-              <Skeleton className="h-10 w-28 rounded-xl bg-muted/35" />
-              <Skeleton className="h-10 w-24 rounded-xl bg-muted/35" />
-            </div>
-          </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
-            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
-            <Skeleton className="h-28 w-full rounded-2xl bg-muted/35" />
-          </div>
-          <Skeleton className="h-12 w-full max-w-md rounded-xl bg-muted/35" />
-          <Skeleton className="h-[420px] w-full rounded-2xl bg-muted/30" />
-        </div>
-      </div>
-    </PageShell>
-  );
+  return <TalentDashboardSkeleton />;
 }

--- a/app/talent/signup/loading.tsx
+++ b/app/talent/signup/loading.tsx
@@ -1,28 +1,24 @@
-import { PageShell } from "@/components/layout/page-shell";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
 import { SectionCard } from "@/components/layout/section-card";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
 import { Skeleton } from "@/components/ui/skeleton";
 
 export default function TalentSignupLoading() {
   return (
-    <PageShell fullBleed className="grain-texture glow-backplate relative overflow-x-hidden text-white">
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-
-      <div className="relative z-10 container mx-auto px-4 py-12 sm:px-6 lg:px-8">
+    <AuthLoadingShell ribbonFootline="Building your onboarding…">
+      <div className="container mx-auto px-4 pb-12 pt-1 sm:px-6 lg:px-8">
         <div className="mb-8 h-5 w-24 animate-pulse rounded bg-white/10" />
 
         <SectionCard className="mx-auto max-w-4xl overflow-hidden" paddingClassName="p-0">
           <div className="grid md:grid-cols-5">
             <div className="relative hidden md:col-span-2 md:block">
-              <div className="aspect-[3/4] bg-white/10" />
+              <div className="aspect-[3/4] bg-white/[0.06]" />
             </div>
 
             <div className="space-y-6 p-6 sm:p-8 md:col-span-3">
               <div className="mb-8 space-y-2">
                 <Skeleton className="mb-2 h-8 w-48 bg-white/10" />
                 <Skeleton className="h-4 w-full bg-white/10" />
-                <Skeleton className="h-4 w-3/4 bg-white/10" />
+                <Skeleton className="h-4 w-[75%] bg-white/10" />
               </div>
 
               <Skeleton className="mb-6 h-4 w-full bg-white/10" />
@@ -47,7 +43,7 @@ export default function TalentSignupLoading() {
                 <div className="space-y-2">
                   <Skeleton className="mb-2 h-4 w-24 bg-white/10" />
                   <Skeleton className="h-10 w-full bg-white/10" />
-                  <Skeleton className="h-4 w-3/4 bg-white/10" />
+                  <Skeleton className="h-4 w-[75%] bg-white/10" />
                 </div>
 
                 <div className="space-y-2">
@@ -57,7 +53,7 @@ export default function TalentSignupLoading() {
 
                 <div className="flex items-center space-x-2">
                   <Skeleton className="h-4 w-4 bg-white/10" />
-                  <Skeleton className="h-4 w-64 bg-white/10" />
+                  <Skeleton className="h-4 w-64 max-w-full bg-white/10" />
                 </div>
 
                 <Skeleton className="h-12 w-full bg-white/10" />
@@ -66,6 +62,6 @@ export default function TalentSignupLoading() {
           </div>
         </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/app/update-password/loading.tsx
+++ b/app/update-password/loading.tsx
@@ -1,18 +1,27 @@
-import { PageShell } from "@/components/layout/page-shell";
-import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { AuthLoadingShell } from "@/components/layout/auth-loading-shell";
+import { SectionCard } from "@/components/layout/section-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRail } from "@/components/ui/totl-brand-loading";
 
 export default function UpdatePasswordLoading() {
   return (
-    <PageShell
-      fullBleed
-      className="grain-texture glow-backplate relative overflow-x-hidden text-white"
-    >
-      <FloatingPathsBackground opacity={0.08} color="white" />
-      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
-      <div className="relative z-10 flex min-h-[60vh] items-center justify-center px-4">
-        <LoadingSpinner size="lg" className="text-white" />
+    <AuthLoadingShell ribbonFootline="Securing password update…">
+      <div className="flex min-h-[52vh] items-center justify-center px-4 pb-16 pt-2">
+        <SectionCard className="w-full max-w-md overflow-hidden" paddingClassName="p-6 sm:p-8">
+          <div className="space-y-5">
+            <div className="space-y-1 text-center">
+              <Skeleton className="mx-auto h-7 w-52 rounded-lg bg-white/10" />
+              <Skeleton className="mx-auto h-4 w-[90%] max-w-[17rem] rounded-lg bg-white/10" />
+            </div>
+            <TotlBrandLoadingRail className="opacity-95" />
+            <div className="space-y-3 pt-2">
+              <Skeleton className="h-10 w-full rounded-lg bg-white/10" />
+              <Skeleton className="h-10 w-full rounded-lg bg-white/10" />
+              <Skeleton className="h-11 w-full rounded-lg bg-white/10" />
+            </div>
+          </div>
+        </SectionCard>
       </div>
-    </PageShell>
+    </AuthLoadingShell>
   );
 }

--- a/components/admin/admin-loading-shell.tsx
+++ b/components/admin/admin-loading-shell.tsx
@@ -1,5 +1,7 @@
 import type React from "react";
 
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
+
 /**
  * Dark-themed loading shell for admin routes.
  * Matches AdminHeader + PageShell aesthetic to prevent white flash and maintain immersion.
@@ -7,7 +9,9 @@ import type React from "react";
  */
 export function AdminLoadingShell({ children }: { children: React.ReactNode }) {
   return (
-    <div className="page-ambient min-h-screen text-white">
+    <div className="relative min-h-screen bg-[var(--oklch-bg)] page-ambient text-white">
+      <div className="pointer-events-none fixed inset-0 z-0 totl-brand-loading-warm-veil" aria-hidden />
+
       {/* Skeleton header matching AdminHeader layout */}
       <header className="panel-frosted sticky top-0 z-40 border-b border-border/40">
         <div className="container mx-auto px-4 py-4">
@@ -15,24 +19,32 @@ export function AdminLoadingShell({ children }: { children: React.ReactNode }) {
             <div className="flex min-w-0 items-center gap-3">
               <div className="h-10 w-10 rounded-full bg-white/10 animate-pulse" />
               <div className="space-y-2">
-                <div className="h-5 w-32 bg-white/10 rounded animate-pulse" />
-                <div className="h-3 w-48 bg-white/10 rounded animate-pulse" />
+                <div className="h-5 w-32 animate-pulse rounded bg-white/10" />
+                <div className="h-3 w-48 animate-pulse rounded bg-white/10" />
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <div className="h-9 w-24 bg-white/10 rounded animate-pulse" />
-              <div className="h-9 w-20 bg-white/10 rounded animate-pulse" />
+              <div className="h-9 w-24 animate-pulse rounded bg-white/10" />
+              <div className="h-9 w-20 animate-pulse rounded bg-white/10" />
             </div>
           </div>
           <nav className="mt-3 flex flex-wrap gap-2">
             {[1, 2, 3, 4, 5, 6].map((i) => (
-              <div key={i} className="h-9 w-20 bg-white/10 rounded-lg animate-pulse" />
+              <div key={i} className="h-9 w-20 animate-pulse rounded-lg bg-white/10" />
             ))}
           </nav>
         </div>
       </header>
 
-      <div className="container mx-auto px-4 py-6 sm:px-6 lg:px-8">{children}</div>
+      <div className="relative z-[1] container mx-auto px-4 py-6 sm:px-6 lg:px-8">
+        <TotlBrandLoadingRibbon
+          compact
+          eyebrow="Admin console"
+          footline="Applying controls…"
+          className="mb-6 max-w-lg"
+        />
+        {children}
+      </div>
     </div>
   );
 }

--- a/components/dashboard/client-dashboard-skeleton.tsx
+++ b/components/dashboard/client-dashboard-skeleton.tsx
@@ -1,11 +1,19 @@
 import { PageShell } from "@/components/layout/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
 
 export function ClientDashboardSkeleton() {
   return (
-    <PageShell ambientTone="lifted" topPadding={false} fullBleed>
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed routeRole="client">
       <div className="container mx-auto px-4 py-3 sm:px-6 sm:py-6 lg:px-8">
         <div className="mx-auto w-full max-w-6xl space-y-8">
+          <TotlBrandLoadingRibbon
+            compact
+            eyebrow="Career Builder"
+            footline="Composing your pipeline…"
+            className="max-w-xl pb-2"
+          />
+
           {/* Header */}
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-2">

--- a/components/dashboard/talent-dashboard-skeleton.tsx
+++ b/components/dashboard/talent-dashboard-skeleton.tsx
@@ -1,0 +1,61 @@
+import { PageShell } from "@/components/layout/page-shell";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
+
+/** Matches talent dashboard Career Builder chrome; used by route loader + Suspense streaming. */
+export function TalentDashboardSkeleton() {
+  return (
+    <PageShell ambientTone="lifted" topPadding={false} fullBleed routeRole="talent">
+      <div className="px-4 py-8">
+        <div className="mx-auto w-full max-w-6xl space-y-8">
+          <TotlBrandLoadingRibbon
+            compact
+            eyebrow="Talent terminal"
+            footline="Sharpening your dashboard…"
+            className="max-w-xl"
+          />
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-12 w-12 shrink-0 rounded-full bg-muted/35" />
+              <div className="space-y-2">
+                <Skeleton className="h-7 w-56 max-w-[min(14rem,100%)] rounded-lg bg-muted/40" />
+                <Skeleton className="h-4 w-72 max-w-full rounded-lg bg-muted/35" />
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-10 w-28 rounded-xl bg-muted/35" />
+              <Skeleton className="h-10 w-24 rounded-xl bg-muted/35" />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                className="panel-frosted card-backlit rounded-2xl p-5"
+              >
+                <Skeleton className="mb-4 h-3 w-20 rounded-lg bg-muted/35" />
+                <Skeleton className="h-9 w-14 rounded-lg bg-muted/45" />
+                <Skeleton className="mt-4 h-2.5 w-28 rounded-lg bg-muted/25" />
+              </div>
+            ))}
+          </div>
+
+          <Skeleton className="h-12 w-full max-w-md rounded-xl bg-muted/35" />
+
+          <div className="panel-frosted card-backlit overflow-hidden rounded-2xl border border-border/40">
+            <div className="space-y-3 border-b border-border/35 px-5 py-4 sm:px-6">
+              <Skeleton className="h-6 w-48 max-w-full rounded-lg bg-muted/40" />
+              <Skeleton className="h-3.5 w-72 max-w-full rounded-lg bg-muted/28" />
+            </div>
+            <div className="p-4 sm:p-6">
+              <Skeleton className="h-[min(420px,65vh)] w-full rounded-xl bg-muted/28" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/components/home/home-page-client.tsx
+++ b/components/home/home-page-client.tsx
@@ -6,6 +6,7 @@ import { PostGigFooterLink } from "@/components/post-gig-footer-link";
 import { Button } from "@/components/ui/button";
 import { SafeImage } from "@/components/ui/safe-image";
 import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
+import { TotlEditorialSection } from "@/components/ui/totl-editorial-section";
 import { TotlSectionDivider } from "@/components/ui/totl-section-divider";
 import type { HomeFeaturedGig } from "@/lib/home-featured-gigs";
 
@@ -49,7 +50,7 @@ export function HomePageClient({ featuredGigs }: { featuredGigs: HomeFeaturedGig
   return (
     <TotlAtmosphereShell className="text-white">
       <main className="relative">
-        <section className="relative overflow-hidden pt-24 sm:pt-28 lg:pt-32">
+        <TotlEditorialSection className="relative overflow-hidden pt-24 sm:pt-28 lg:pt-32">
           <div className="container mx-auto px-4 pb-16 sm:px-6 sm:pb-20 lg:px-8 lg:pb-24">
             <div className="grid items-center gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)] lg:gap-16">
               <div className="max-w-2xl space-y-8">
@@ -170,7 +171,7 @@ export function HomePageClient({ featuredGigs }: { featuredGigs: HomeFeaturedGig
               </div>
             </div>
           </div>
-        </section>
+        </TotlEditorialSection>
 
         <TotlSectionDivider variant="hero" />
 

--- a/components/layout/auth-loading-shell.tsx
+++ b/components/layout/auth-loading-shell.tsx
@@ -1,0 +1,60 @@
+import type React from "react";
+
+import { PageShell } from "@/components/layout/page-shell";
+import { FloatingPathsBackground } from "@/components/ui/floating-paths-background";
+import { TotlBrandLoadingRibbon } from "@/components/ui/totl-brand-loading";
+import { cn } from "@/lib/utils/utils";
+
+export interface AuthLoadingShellProps {
+  children: React.ReactNode;
+  /** Merged onto `PageShell` outer class. */
+  className?: string;
+  /** Content wrapper (`relative z-10`): use for `container mx-auto px-4 …` like `AuthEntryShell`. */
+  innerClassName?: string;
+  showBrandRibbon?: boolean;
+  /** Passed through when ribbon is visible. */
+  ribbonFootline?: string;
+  ribbonEyebrow?: string;
+  ribbonCompact?: boolean;
+  ribbonRail?: boolean;
+}
+
+/** Shared atmospheric wrapper for `/login`, signup, and recovery route `loading.tsx` trees. */
+export function AuthLoadingShell({
+  children,
+  className,
+  innerClassName,
+  showBrandRibbon = true,
+  ribbonEyebrow = "TOTL Agency",
+  ribbonFootline = "Preparing your session…",
+  ribbonCompact = true,
+  ribbonRail = true,
+}: AuthLoadingShellProps) {
+  return (
+    <PageShell
+      fullBleed
+      className={cn(
+        "grain-texture glow-backplate relative overflow-x-hidden text-white",
+        className
+      )}
+    >
+      <FloatingPathsBackground opacity={0.08} color="white" />
+      <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-br from-white/5 via-transparent to-white/5 opacity-40" />
+
+      <div className={cn("relative z-10", innerClassName)}>
+        {showBrandRibbon ? (
+          <div className="container mx-auto px-4 pt-5 sm:px-6 sm:pt-6 md:pt-7 lg:px-8">
+            <TotlBrandLoadingRibbon
+              compact={ribbonCompact}
+              rail={ribbonRail}
+              eyebrow={ribbonEyebrow}
+              footline={ribbonFootline}
+              className="pb-5 sm:pb-6"
+            />
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </PageShell>
+  );
+}

--- a/components/ui/totl-brand-loading.tsx
+++ b/components/ui/totl-brand-loading.tsx
@@ -1,0 +1,112 @@
+import type React from "react";
+
+import {
+  TotlAtmosphereShell,
+  type TotlAmbientTone,
+} from "@/components/ui/totl-atmosphere-shell";
+import { cn } from "@/lib/utils/utils";
+
+/** Slim indeterminate progress rail — no spinner; complements skeleton layouts. */
+export function TotlBrandLoadingRail({
+  className,
+  label = "Loading",
+}: {
+  className?: string;
+  /** Shown via aria-label only (localized per surface if needed). */
+  label?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "totl-brand-loading-rail h-[2px] w-full overflow-hidden rounded-full bg-white/[0.08]",
+        className
+      )}
+      role="progressbar"
+      aria-label={label}
+      aria-busy="true"
+    >
+      <div className="totl-brand-loading-rail__bar h-full rounded-full shadow-[0_0_14px_rgba(196,181,253,0.35)]" />
+    </div>
+  );
+}
+
+export function TotlBrandLoadingRibbon({
+  className,
+  eyebrow,
+  footline,
+  rail = true,
+  compact,
+}: {
+  className?: string;
+  eyebrow?: string;
+  rail?: boolean;
+  footline?: string;
+  compact?: boolean;
+}) {
+  return (
+    <div className={cn("space-y-3", compact && "space-y-2", className)}>
+      {eyebrow ? (
+        <p className={cn(
+          "text-[10px] font-medium uppercase tracking-[0.26em] text-[var(--totl-text-soft)] sm:text-[11px]",
+          compact && "text-[10px]"
+        )}
+        >
+          {eyebrow}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="flex items-center gap-2">
+          <span aria-hidden className="h-[7px] w-[7px] shrink-0 rounded-full bg-violet-300 shadow-[0_0_14px_rgba(196,181,253,0.75)]" />
+          <p className={cn(
+            "font-display text-xl font-semibold tracking-[-0.06em] text-white sm:text-2xl",
+            compact && "text-lg sm:text-xl"
+          )}
+          >
+            <span className="totl-text-gradient">TOTL</span>
+            <span className="ml-2 text-[0.92em] font-medium tracking-normal text-white/85">Agency</span>
+          </p>
+        </div>
+      </div>
+      {footline ? (
+        <p className={cn(
+          "text-xs text-[var(--totl-text-soft)] sm:text-[13px]",
+          compact && "text-[11px] sm:text-xs"
+        )}
+        >
+          {footline}
+        </p>
+      ) : null}
+      {rail ? <TotlBrandLoadingRail className="max-w-xl" /> : null}
+    </div>
+  );
+}
+
+/** Marketing/root loading: full atmospheric shell plus optional warm veil over content lane. */
+export function TotlMarketingLoadingBackdrop({
+  children,
+  className,
+  ambientTone = "default",
+  grain = true,
+  contentClassName,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  ambientTone?: TotlAmbientTone;
+  grain?: boolean;
+  /** Extra classes on inner content stacking context (ribbon + skeleton live here). */
+  contentClassName?: string;
+}) {
+  return (
+    <TotlAtmosphereShell
+      ambientTone={ambientTone}
+      className={cn("text-white", grain && "grain-texture min-h-[100dvh]", className)}
+      contentClassName={cn(
+        "relative flex min-h-[100dvh] flex-col bg-transparent",
+        contentClassName
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 z-0 totl-brand-loading-warm-veil" aria-hidden />
+      <div className="relative z-[3] flex min-h-0 flex-1 flex-col">{children}</div>
+    </TotlAtmosphereShell>
+  );
+}

--- a/components/ui/totl-editorial-section.tsx
+++ b/components/ui/totl-editorial-section.tsx
@@ -1,0 +1,22 @@
+import type React from "react";
+
+import { cn } from "@/lib/utils/utils";
+
+/** Native section props forwarded (e.g. `aria-labelledby`). */
+export type TotlEditorialSectionProps = React.ComponentPropsWithoutRef<"section">;
+
+/**
+ * Section-level editorial spotlight: soft canopy wash + faint horizon line (`::before` / `::after` in `globals.css`).
+ * CSS-only, compositor-friendly opacity pulse — use for hero bands on marketing and high-traffic list pages.
+ */
+export function TotlEditorialSection({
+  children,
+  className,
+  ...props
+}: TotlEditorialSectionProps) {
+  return (
+    <section className={cn("totl-editorial-canopy", className)} {...props}>
+      {children}
+    </section>
+  );
+}

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** May 3, 2026 (Career Builder admin vetting + comp-card profile field pass + image resize guidance)
+**Last Updated:** May 3, 2026 — Doc spine refreshed (editorial canopy + branded loading primitives; staleness cues on indices). Source of truth: `features/UI_VISUAL_LANGUAGE.md`, `UI_IMPLEMENTATION_INDEX.md`, `components/layout/*`, `components/ui/*`.
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 
@@ -163,7 +163,7 @@ All other documentation has been organized into the `docs/` folder with the foll
 - `STATUS_BADGE_SYSTEM.md` - 🎨 **NEW** - Comprehensive status badge system with 25+ variants (Nov 2025)
 - `UI_LAYOUT_CONTRACT.md` - 🎨 **NEW** - Canonical Terminal Kit (PageShell/PageHeader/SectionCard/DataTableShell) + mobile safety rules (Dec 2025)
 - `TOTL_ENHANCEMENT_IMPLEMENTATION_PLAN.md` - 🚀 **NEW** - Comprehensive enhancement roadmap for "sellable for millions" marketplace (Jan 2025)
-- `UI_VISUAL_LANGUAGE.md` - 🎨 **NEW** - Visual design system and component guidelines (Jan 2025)
+- `UI_VISUAL_LANGUAGE.md` - 🎨 **CANONICAL** — Design system + layout shells (**`TotlEditorialSection`**, **`TotlBrandLoading*`**, **`AuthLoadingShell`**) — refreshed May 2026
 - `BOOKING_FLOW_IMPLEMENTATION.md` - Booking workflow implementation
 - `PORTFOLIO_GALLERY_IMPLEMENTATION.md` - Portfolio gallery (current behavior; see also `contracts/PORTFOLIO_UPLOADS_CONTRACT.md`)
 - `guides/OPPORTUNITY_IMAGE_SPECS.md` - Opportunity cover image dimensions (1200×900 px, 4:3) for flyers

--- a/docs/UI_IMPLEMENTATION_INDEX.md
+++ b/docs/UI_IMPLEMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency - UI Implementation Index (Doc <-> Code Lock)
 
-**Date:** March 3, 2026  
+**Date:** May 3, 2026  
 **Status:** Canonical implementation index for UI governance  
 **Primary law:** `docs/UI_CONSTITUTION.md`  
 **Purpose:** Prevent contract drift by mapping each UI law to the exact owning primitive(s) in code.
@@ -45,6 +45,7 @@ If a route violates the constitution and does not use the owning primitive, it i
 | Talent terminal header/nav chrome | Route-local + shared shell (no single dedicated talent header primitive yet) | Marked in-progress; avoid introducing parallel talent header components |
 | Secondary filters in a sheet | `components/dashboard/filters-sheet.tsx` (`FiltersSheet`) | Canonical mobile secondary filter container |
 | Mobile KPI density control | `components/dashboard/mobile-summary-row.tsx` (`MobileSummaryRow`) | Use for compact summary instead of fat KPI stacks |
+| Editorial / marketing hero canopy (section spotlight) | `components/ui/totl-editorial-section.tsx` (`TotlEditorialSection`) + `.totl-editorial-canopy` in **`app/globals.css`** | Lightweight wash for `/`, `/gigs` hero bands; avoids extra JS |
 | Canonical page shell and heading | `components/layout/page-shell.tsx` (`PageShell`), `components/layout/page-header.tsx` (`PageHeader`) | Required baseline for new/touched full pages |
 | Data table overflow handling | `components/layout/data-table-shell.tsx` (`DataTableShell`) | Required for table-like layouts on mobile |
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,12 +1,12 @@
 # Features Docs Index
 
-**Date:** March 9, 2026  
+**Date:** May 3, 2026  
 **Status:** ✅ ACTIVE  
 **Purpose:** Provide a navigable entry point for feature implementation docs, PR summaries, UI contracts, and product-specific execution notes.
 
 ## Start Here
 
-- `UI_VISUAL_LANGUAGE.md` - design language and visual system guidance
+- `UI_VISUAL_LANGUAGE.md` — design language, layout shells (**`TotlEditorialSection`**, **`TotlBrandLoading*`**, **`AuthLoadingShell`**), loaders
 - `UI_LAYOUT_CONTRACT.md` - layout and shell contract
 - `STATUS_BADGE_SYSTEM.md` - badge language and variants
 - `CLIENT_ACCOUNT_FLOW_PRD.md` - client account flow product definition

--- a/docs/features/UI_VISUAL_LANGUAGE.md
+++ b/docs/features/UI_VISUAL_LANGUAGE.md
@@ -77,6 +77,10 @@ Use these when composing full-page or section-level structure so surfaces stay c
 - **`PageShell`** — `components/layout/page-shell.tsx` — default route wrapper (`page-ambient`, container width, nav top offset); use `fullBleed` when the page controls its own horizontal layout.
 - **`SectionCard`** — `components/layout/section-card.tsx` — canonical frosted panel stack (`panel-frosted` + `card-backlit` + `grain-texture`) for grouped content.
 - **`AuthEntryShell`** — `components/layout/auth-entry-shell.tsx` — full-bleed auth/recovery entry (atmosphere + optional back link + `SectionCard`). Props: `omitBackLink`, `panelClassName` / `panelPaddingClassName` for wider holds (e.g. suspended). Container spacing aligns with `/login` (`py-4 sm:py-6 md:py-8`).
+- **`TotlMarketingLoadingBackdrop`**, **`TotlBrandLoadingRibbon`**, **`TotlBrandLoadingRail`** — `components/ui/totl-brand-loading.tsx` — marketing/root **`loading.tsx`** backdrop (**`TotlAtmosphereShell`** + grain + warm veil lane), branded wordmark block, and slim indeterminate rail (`role="progressbar"`, `aria-busy`; CSS `.totl-brand-loading-rail__bar` in **`app/globals.css`**, toned down under `prefers-reduced-motion`).
+- **`TotlEditorialSection`** — `components/ui/totl-editorial-section.tsx` — section-sized editorial canopy (CSS **`.totl-editorial-canopy`** in **`app/globals.css`**: soft radial washes; opacity-only drift when motion is allowed). Use on marketing and high-traffic list heroes (`/`, `/gigs`).
+- **`AuthLoadingShell`** — `components/layout/auth-loading-shell.tsx` — Paths + vignette wrapper for **`/login`**, signup, and recovery loaders; optionally shows **`TotlBrandLoadingRibbon`** for a consistent auth brand moment.
+- **Dashboard loaders:** Pass **`routeRole`** on **`PageShell`** in **`ClientDashboardSkeleton`** / **`TalentDashboardSkeleton`** so `[data-role]` ambient matches terminal routes.
 
 ## Mobile UX Guidelines
 


### PR DESCRIPTION
## What broke

Route transitions and waits often surfaced generic skeletons/spinners, a plain Suspense fallback on the talent dashboard, and flat hero framing on flagship pages (`/` and `/gigs`). Not a reliability outage, but the product felt slower and less intentional than its final chrome.

## Why it broke

Loading and hero treatments had evolved per-route without a shared, branded primitive; Suspense/streaming shells were inconsistent; docs did not consistently point authors at the owning components and CSS utilities.

## What we changed

- Introduced **`TotlBrandLoadingRibbon`** / **`TotlBrandLoadingRail`** / **`TotlMarketingLoadingBackdrop`** plus **`AuthLoadingShell`**, keyed rail/veil styles in **`app/globals.css`**, and rewired loaders (auth, admin, dashboards, gigs, root **`app/loading`**).
- **`TalentDashboardSkeleton`** + Suspense fallback in **`app/talent/dashboard/client.tsx`** (replacing plaintext loading).
- **`TotlEditorialSection`** + **`.totl-editorial-canopy`** for marketing/list hero bands (**`/`**, **`/gigs`**, root loading parity).
- Refreshed **`MVP_STATUS_NOTION.md`**, **`docs/DOCUMENTATION_INDEX.md`**, **`docs/UI_IMPLEMENTATION_INDEX.md`**, **`docs/features/README.md`**, **`docs/features/UI_VISUAL_LANGUAGE.md`**.

## How we proved it

Commands actually run:

- **`npm run schema:verify:comprehensive`** — pass
- **`npm run types:check`** — pass
- **`npm run build`** — pass (run again locally before push; repo pre-commit hook also invokes a production build path)
- **`npm run lint`** — pass

Manual route-by-route checks were **not** run in automation for this merge; suggested: `/`, `/login`, `/gigs`, `/client/dashboard`, `/talent/dashboard`, `/admin`; toggle **prefers-reduced-motion** once.

## Branch scope honesty

Current **`origin/main...origin/develop`** delta is exactly **one** commit (`fix(ui): premium branded loading and editorial hero canopy`). Earlier Career Builder/opportunity bundles are already on **`main`** / merged historically.

Docs updated: **yes**

- `MVP_STATUS_NOTION.md`
- `docs/DOCUMENTATION_INDEX.md`
- `docs/UI_IMPLEMENTATION_INDEX.md`
- `docs/features/README.md`
- `docs/features/UI_VISUAL_LANGUAGE.md`

---

**Risk level:** Low

**Rollback plan:** If anything regresses in production visuals, revert the merge commit on `main` or fast-forward-reset `develop` and redeploy—the change is purely UI/CSS primitives and route loaders without schema or migrations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes: replaces route `loading.tsx` UIs and adds new global CSS animations/overlays, with no auth/business logic or data handling changes.
> 
> **Overview**
> Introduces shared, branded loading primitives—`TotlBrandLoadingRibbon`/`TotlBrandLoadingRail`/`TotlMarketingLoadingBackdrop` plus `AuthLoadingShell`—and updates global CSS for the indeterminate rail, warm veil overlay, and reduced-motion behavior.
> 
> Replaces generic spinners/plain “Loading…” fallbacks across core routes (root `app/loading.tsx`, auth loaders, dashboards, admin shell, gigs list/detail) with these branded skeleton + ribbon treatments, including a new `TalentDashboardSkeleton` used for both the route loader and Suspense fallback.
> 
> Adds `TotlEditorialSection` (CSS `.totl-editorial-canopy`) and applies it to the homepage hero and `/gigs` headline band to give consistent editorial framing; updates MVP status + documentation indices to reflect the new UI primitives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bb305a8538b68ed44fc9d0fd25a6e610aa9cda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->