### PR TITLE
fix(ui): align client admin and talent surfaces to PageShell

### DIFF
--- a/MVP_STATUS_NOTION.md
+++ b/MVP_STATUS_NOTION.md
@@ -8,6 +8,26 @@
 
 # 🎉 CURRENT STATUS: MVP COMPLETE WITH SUBSCRIPTION SYSTEM!
 
+## 🚀 **Latest: Shared PageShell + PageHeader alignment (May 5, 2026)**
+
+**UI / PRIMITIVES** — May 5, 2026
+- ✅ **Client terminal:** `/client/applications`, `/client/gigs`, `/client/bookings` use **`PageShell`** (`ambientTone="lifted"`, `routeRole="client"`, `topPadding={false}`, `fullBleed`) instead of ad-hoc **`TotlAtmosphereShell`**; applications shows **`MobileSummaryRow`** on mobile without a collapsed stats disclosure.
+- ✅ **Admin:** `/admin/applications/[id]` matches dashboard shell (**`PageShell`** + **`AdminHeader`** + **`PageHeader`**); **`/admin/gigs/success`** uses **`PageShell`** with `routeRole="admin"`.
+- ✅ **Public talent:** `/talent/[slug]` uses **`PageShell`** + **`PageHeader`** (breadcrumbs, back action); hero no longer duplicates the title; body sections use shared OKLCH text tokens and slightly tighter mobile headings.
+- ✅ **Docs:** `docs/features/UI_VISUAL_LANGUAGE.md` (PageShell interior pattern); `docs/DOCUMENTATION_INDEX.md` staleness line.
+
+**Verification (May 5 ship run):**
+- ✅ `npm run schema:verify:comprehensive` — pass
+- ✅ `npm run types:check` — pass
+- ✅ `npm run build` — pass
+- ✅ `npm run lint` — pass
+
+**Next (P0):** Staging smoke — client applications / gigs / bookings, admin application detail + gig success, public talent profile on narrow viewports.
+
+**Next (P1):** Sweep remaining interiors per **`docs/work-orders/TOTL_VISUAL_STYLE_ALIGNMENT_WORK_ORDER.md`**; migrate stragglers off raw **`TotlAtmosphereShell`** where **`PageShell`** is appropriate.
+
+---
+
 ## 🚀 **Latest: Premium branded loading + editorial canopy + docs spine (May 2026)**
 
 **UI / PERFORMANCE / DOCUMENTATION**

--- a/PROJECT_STATUS_REPORT.md
+++ b/PROJECT_STATUS_REPORT.md
@@ -206,6 +206,8 @@ Based on `docs/TOTL_ENHANCEMENT_IMPLEMENTATION_PLAN.md`, you are currently in:
 
 ## 🎯 Immediate Next Steps (Priority Order)
 
+The current catch-up queue lives in `docs/plans/TOTL_CATCHUP_ROADMAP.md` and `docs/work-orders/README.md`.
+
 ### **Priority 0: Critical Fixes (P0)**
 1. **Onboarding spine polish** - Verify BootState routing in preview/prod
 2. **Playwright admin test helper env** - Fix SUPABASE_SERVICE_ROLE_KEY alignment

--- a/app/admin/applications/[id]/admin-application-detail-client.tsx
+++ b/app/admin/applications/[id]/admin-application-detail-client.tsx
@@ -15,6 +15,9 @@ import {
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { PageHeader } from "@/components/layout/page-header";
+import { PageShell } from "@/components/layout/page-shell";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -29,7 +32,6 @@ import {
 import { Label } from "@/components/ui/label";
 import { ApplicationStatusBadge } from "@/components/ui/status-badge";
 import { Textarea } from "@/components/ui/textarea";
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { useToast } from "@/components/ui/use-toast";
 import { adminSetApplicationStatusAction } from "@/lib/actions/admin-application-actions";
 import { userSafeMessageFromActionError } from "@/lib/errors/user-safe-message";
@@ -81,11 +83,12 @@ type ApplicationWithDetails = Database["public"]["Tables"]["applications"]["Row"
 
 interface AdminApplicationDetailClientProps {
   application: ApplicationWithDetails;
-  user?: User; // Optional since it's not used in component
+  user: User;
 }
 
 export function AdminApplicationDetailClient({
   application,
+  user,
 }: AdminApplicationDetailClientProps) {
   const router = useRouter();
   const { toast } = useToast();
@@ -186,50 +189,47 @@ export function AdminApplicationDetailClient({
   const talentProfileHref = application.talent_id ? `/talent/${application.talent_id}` : null;
 
   return (
-    <TotlAtmosphereShell ambientTone="lifted" className="min-h-screen text-[var(--oklch-text-primary)]">
-      <div className="container mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="mb-8">
-          <Link
-            href="/admin/applications"
-            className="mb-4 inline-flex items-center text-[var(--oklch-text-secondary)] transition-colors hover:text-white"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Applications
-          </Link>
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-white mb-2">Application Details</h1>
-              <p className="text-[var(--oklch-text-secondary)]">
-                Application ID: {application.id.slice(0, 8)}...
-              </p>
-            </div>
-            <div className="flex gap-2">
-              {application.status === "new" || application.status === "under_review" ? (
-                <>
-                  <Button
-                    variant="outline"
-                    className="border-green-700 text-green-400 hover:bg-green-900/20 hover:text-green-300"
-                    onClick={() => setShowApproveDialog(true)}
-                  >
-                    <CheckCircle className="mr-2 h-4 w-4" />
-                    Approve
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="border-red-700 text-red-400 hover:bg-red-900/20 hover:text-red-300"
-                    onClick={() => setShowRejectDialog(true)}
-                  >
-                    <XCircle className="mr-2 h-4 w-4" />
-                    Reject
-                  </Button>
-                </>
-              ) : null}
-            </div>
-          </div>
-        </div>
+    <PageShell topPadding={false} fullBleed ambientTone="lifted">
+      <AdminHeader user={user} />
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-5 sm:py-8">
+        <PageHeader
+          title="Application details"
+          subtitle={`Application ID: ${application.id.slice(0, 8)}...`}
+          breadcrumbs={
+            <Link
+              href="/admin/applications"
+              className="inline-flex items-center gap-2 text-[var(--oklch-text-secondary)] transition-colors hover:text-[var(--oklch-text-primary)]"
+            >
+              <ArrowLeft className="h-4 w-4 shrink-0" />
+              Back to applications
+            </Link>
+          }
+          actions={
+            application.status === "new" || application.status === "under_review" ? (
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  variant="outline"
+                  className="border-green-700 text-green-400 hover:bg-green-900/20 hover:text-green-300"
+                  onClick={() => setShowApproveDialog(true)}
+                >
+                  <CheckCircle className="mr-2 h-4 w-4" />
+                  Approve
+                </Button>
+                <Button
+                  variant="outline"
+                  className="border-red-700 text-red-400 hover:bg-red-900/20 hover:text-red-300"
+                  onClick={() => setShowRejectDialog(true)}
+                >
+                  <XCircle className="mr-2 h-4 w-4" />
+                  Reject
+                </Button>
+              </div>
+            ) : undefined
+          }
+          className="mb-6 sm:mb-8"
+        />
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           {/* Main Content */}
           <div className="lg:col-span-2 space-y-6">
             {/* Application Info */}
@@ -596,7 +596,7 @@ export function AdminApplicationDetailClient({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </TotlAtmosphereShell>
+    </PageShell>
   );
 }
 

--- a/app/admin/applications/[id]/page.tsx
+++ b/app/admin/applications/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { redirect, notFound } from "next/navigation";
 import { AdminApplicationDetailClient } from "./admin-application-detail-client";
-import { AdminHeader } from "@/components/admin/admin-header";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 import { logger } from "@/lib/utils/logger";
 import { type ProfileRow } from "@/types/database-helpers";
@@ -148,11 +147,6 @@ export default async function AdminApplicationDetailPage({
     notFound();
   }
 
-  return (
-    <>
-      <AdminHeader user={user} />
-      <AdminApplicationDetailClient application={applicationWithDetails} user={user} />
-    </>
-  );
+  return <AdminApplicationDetailClient application={applicationWithDetails} user={user} />;
 }
 

--- a/app/admin/gigs/success/page.tsx
+++ b/app/admin/gigs/success/page.tsx
@@ -4,9 +4,9 @@ import { CheckCircle, Clock, Users } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
+import { PageShell } from "@/components/layout/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { useToast } from "@/components/ui/use-toast";
 
 export default function GigSuccessPage() {
@@ -24,31 +24,32 @@ export default function GigSuccessPage() {
 
   if (!gigId) {
     return (
-      <TotlAtmosphereShell ambientTone="lifted" className="min-h-screen text-[var(--oklch-text-primary)]">
-        <div className="container mx-auto px-4 py-12">
-          <div className="mx-auto max-w-lg text-center">
-            <div className="panel-frosted card-backlit rounded-2xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-8">
-              <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/15">
-                <Clock className="h-8 w-8 text-red-400" />
-              </div>
-              <h2 className="text-2xl font-semibold text-white">Invalid Gig ID</h2>
-              <p className="mt-2 text-[var(--oklch-text-secondary)]">
-                No gig ID provided. Please submit an opportunity first.
-              </p>
-              <Button asChild className="mt-6">
-                <Link href="/post-gig">Create New Gig</Link>
-              </Button>
+      <PageShell
+        ambientTone="lifted"
+        routeRole="admin"
+        containerClassName="py-10 sm:py-12 lg:py-16"
+      >
+        <div className="mx-auto max-w-lg text-center">
+          <div className="panel-frosted card-backlit rounded-2xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-6 sm:p-8">
+            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/15">
+              <Clock className="h-8 w-8 text-red-400" />
             </div>
+            <h2 className="text-xl font-semibold text-white sm:text-2xl">Invalid Gig ID</h2>
+            <p className="mt-2 text-sm text-[var(--oklch-text-secondary)] sm:text-base">
+              No gig ID provided. Please submit an opportunity first.
+            </p>
+            <Button asChild className="mt-6">
+              <Link href="/post-gig">Create New Gig</Link>
+            </Button>
           </div>
         </div>
-      </TotlAtmosphereShell>
+      </PageShell>
     );
   }
 
   return (
-    <TotlAtmosphereShell ambientTone="lifted" className="min-h-screen text-[var(--oklch-text-primary)]">
-      <div className="container mx-auto px-4 py-10 sm:py-12">
-        <div className="mx-auto max-w-2xl space-y-8">
+    <PageShell ambientTone="lifted" routeRole="admin" containerClassName="py-10 sm:py-12 lg:py-16">
+      <div className="mx-auto max-w-2xl space-y-8">
           <div className="panel-frosted card-backlit rounded-2xl border border-white/10 bg-[var(--totl-surface-glass-strong)] p-8 text-center">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-500/15">
               <CheckCircle className="h-8 w-8 text-green-400" />
@@ -86,16 +87,15 @@ export default function GigSuccessPage() {
             </div>
           </div>
 
-          <div className="flex flex-col justify-center gap-3 sm:flex-row">
-            <Button asChild variant="outline" className="border-white/10 bg-white/5 text-white hover:bg-white/10">
-              <Link href="/admin/dashboard">Go to Dashboard</Link>
-            </Button>
-            <Button asChild>
-              <Link href="/post-gig">Create Another Gig</Link>
-            </Button>
-          </div>
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Button asChild variant="outline" className="border-white/10 bg-white/5 text-white hover:bg-white/10">
+            <Link href="/admin/dashboard">Go to Dashboard</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/post-gig">Create Another Gig</Link>
+          </Button>
         </div>
       </div>
-    </TotlAtmosphereShell>
+    </PageShell>
   );
 }

--- a/app/client/applications/client-applications-client.tsx
+++ b/app/client/applications/client-applications-client.tsx
@@ -11,10 +11,10 @@ import { FiltersSheet } from "@/components/dashboard/filters-sheet";
 import { MobileSummaryRow } from "@/components/dashboard/mobile-summary-row";
 import { SecondaryActionLink } from "@/components/dashboard/secondary-action-link";
 import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
+import { PageShell } from "@/components/layout/page-shell";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { getClientApplications } from "@/lib/actions/client-applications-actions";
 
 const AcceptApplicationDialog = dynamic(
@@ -204,7 +204,7 @@ export default function ClientApplicationsClient({
     `/talent/${application.talent_id}`;
 
   return (
-    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+    <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
       <ClientTerminalHeader
         title="Applications"
         subtitle="Review and manage talent applications for your opportunities"
@@ -216,19 +216,9 @@ export default function ClientApplicationsClient({
         mobileSecondaryAction={<SecondaryActionLink href="/client/gigs">My opportunities →</SecondaryActionLink>}
       />
 
-      <div className="container mx-auto px-4 py-4 sm:py-6">
-        <div className="mb-4 md:mb-8 md:hidden">
-          <details>
-            <summary className="cursor-pointer list-none text-sm font-medium text-[var(--oklch-text-secondary)]">
-              <span className="inline-flex items-center gap-2">
-                Show stats
-                <span className="text-xs text-[var(--oklch-text-tertiary)]">({applications.length} total)</span>
-              </span>
-            </summary>
-            <div className="mt-2">
-              <MobileSummaryRow items={summaryItems} />
-            </div>
-          </details>
+      <div className="container mx-auto px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        <div className="mb-4 md:hidden">
+          <MobileSummaryRow items={summaryItems} />
         </div>
 
         <div className="mb-8 hidden gap-4 md:grid md:grid-cols-2 lg:grid-cols-4">
@@ -486,6 +476,6 @@ export default function ClientApplicationsClient({
           />
         </>
       )}
-    </TotlAtmosphereShell>
+    </PageShell>
   );
 }

--- a/app/client/bookings/client-bookings-client.tsx
+++ b/app/client/bookings/client-bookings-client.tsx
@@ -11,10 +11,10 @@ import type { Booking } from "@/app/client/bookings/types";
 import { ClientTerminalHeader } from "@/components/client/client-terminal-header";
 import { SecondaryActionLink } from "@/components/dashboard/secondary-action-link";
 import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
+import { PageShell } from "@/components/layout/page-shell";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { useToast } from "@/components/ui/use-toast";
 import { cancelBooking, getClientBookings, updateBookingStatus } from "@/lib/actions/booking-actions";
 import { logActionFailure } from "@/lib/errors/log-action-failure";
@@ -141,7 +141,7 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
 
   if (isLoading) {
     return (
-      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+      <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
         <div className="px-4 py-8">
           <div className="mx-auto w-full max-w-6xl space-y-6">
             <div className="space-y-3">
@@ -156,13 +156,13 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
             <Skeleton className="h-[420px] w-full rounded-2xl border border-white/10 bg-white/5" />
           </div>
         </div>
-      </TotlAtmosphereShell>
+      </PageShell>
     );
   }
 
   if (error) {
     return (
-      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+      <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
         <div className="flex min-h-[100dvh] items-center justify-center px-4">
           <div className="panel-frosted card-backlit max-w-md rounded-2xl p-8 text-center">
             <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-400" />
@@ -173,12 +173,12 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
             <Button onClick={() => mutate()}>Try Again</Button>
           </div>
         </div>
-      </TotlAtmosphereShell>
+      </PageShell>
     );
   }
 
   return (
-    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+    <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
       <ClientTerminalHeader
         title="Bookings"
         subtitle="Manage your confirmed talent bookings"
@@ -197,7 +197,7 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
         }
       />
 
-      <div className="container mx-auto px-4 py-4 sm:py-6">
+      <div className="container mx-auto px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
         <BookingsStatsOverview stats={bookingStats} />
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
@@ -238,6 +238,6 @@ export default function ClientBookingsClient({ userId, initialBookings }: Client
           </TabsContent>
         </Tabs>
       </div>
-    </TotlAtmosphereShell>
+    </PageShell>
   );
 }

--- a/app/client/gigs/client.tsx
+++ b/app/client/gigs/client.tsx
@@ -12,11 +12,11 @@ import useSWR from "swr";
 import { ClientTerminalHeader } from "@/components/client/client-terminal-header";
 import { SecondaryActionLink } from "@/components/dashboard/secondary-action-link";
 import { MobileTabRail } from "@/components/layout/mobile-tab-rail";
+import { PageShell } from "@/components/layout/page-shell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { TotlAtmosphereShell } from "@/components/ui/totl-atmosphere-shell";
 import { getClientGigs, type ClientGig } from "@/lib/actions/client-gigs-actions";
 import { userSafeMessage } from "@/lib/errors/user-safe-message";
 
@@ -113,7 +113,7 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
   // Show error state if Supabase is not configured
   if (error) {
     return (
-      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+      <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
         <div className="flex min-h-[100dvh] items-center justify-center px-4">
           <div className="panel-frosted card-backlit max-w-md rounded-2xl p-8 text-center">
             <AlertCircle className="mx-auto mb-4 h-12 w-12 text-red-400" />
@@ -124,13 +124,13 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
             <Button onClick={() => mutate()}>Try Again</Button>
           </div>
         </div>
-      </TotlAtmosphereShell>
+      </PageShell>
     );
   }
 
   if (isLoading) {
     return (
-      <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+      <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
         <div className="px-4 py-8">
           <div className="mx-auto w-full max-w-6xl space-y-6">
             <div className="space-y-3">
@@ -146,12 +146,12 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
             <Skeleton className="h-[460px] w-full rounded-xl bg-muted/35" />
           </div>
         </div>
-      </TotlAtmosphereShell>
+      </PageShell>
     );
   }
 
   return (
-    <TotlAtmosphereShell ambientTone="lifted" className="text-[var(--oklch-text-primary)]">
+    <PageShell ambientTone="lifted" routeRole="client" topPadding={false} fullBleed>
       <ClientTerminalHeader
         title="My Opportunities"
         subtitle="Manage your posted opportunities and track applications"
@@ -166,7 +166,7 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
         mobileSecondaryAction={<SecondaryActionLink href="/client/post-gig">Post new opportunity →</SecondaryActionLink>}
       />
 
-      <div className="container mx-auto px-4 py-4 sm:py-6">
+      <div className="container mx-auto px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
         <GigsStatsOverview
           totalGigs={gigs.length}
           activeCount={statusCounts.active}
@@ -227,6 +227,6 @@ export default function ClientGigsClient({ userId, initialGigs }: ClientGigsClie
           </TabsContent>
         </Tabs>
       </div>
-    </TotlAtmosphereShell>
+    </PageShell>
   );
 }

--- a/app/talent/[slug]/page.tsx
+++ b/app/talent/[slug]/page.tsx
@@ -1,10 +1,13 @@
-import { ArrowLeft, MapPin } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { TalentProfileClient } from "./talent-profile-client";
+import { PageHeader } from "@/components/layout/page-header";
+import { PageShell } from "@/components/layout/page-shell";
 import { Button } from "@/components/ui/button";
 import { SafeImage } from "@/components/ui/safe-image";
+import { PATHS } from "@/lib/constants/routes";
 import { createSupabaseServer } from "@/lib/supabase/supabase-server";
 import { logger } from "@/lib/utils/logger";
 import { createNameSlug, parseSlug } from "@/lib/utils/slug";
@@ -77,6 +80,24 @@ function normalizeToStringArray(value: string[] | string | null | undefined): st
     }
   }
   return [];
+}
+
+function compCardQuickStats(talent: PublicTalentProfile): { label: string; value: string }[] {
+  const out: { label: string; value: string }[] = [];
+  if (talent.height) out.push({ label: "Height", value: talent.height });
+  if (talent.weight) out.push({ label: "Weight", value: `${talent.weight} lbs` });
+  if (talent.bust && talent.waist && talent.hips) {
+    out.push({
+      label: "Bust · waist · hips",
+      value: `${talent.bust} · ${talent.waist} · ${talent.hips}`,
+    });
+  }
+  if (talent.suit) out.push({ label: "Suit", value: talent.suit });
+  if (talent.shoe_size) out.push({ label: "Shoe", value: talent.shoe_size });
+  if (talent.measurements && !(talent.bust && talent.waist && talent.hips)) {
+    out.push({ label: "Measurements", value: talent.measurements });
+  }
+  return out.slice(0, 6);
 }
 
 // Public talent profile page - dynamic rendering required due to createSupabaseServer() / cookies()
@@ -260,117 +281,140 @@ export default async function TalentProfilePage({ params }: TalentProfilePagePro
     notFound();
   }
 
+  const quickStats = compCardQuickStats(talent);
+  const displayLocation = talent.location?.trim() || null;
+
   return (
-    <div className="min-h-screen bg-seamless-primary">
-      <div className="container mx-auto px-4 py-8">
-        {/* Back Button */}
-        <div className="mb-6">
-          <Link href="/">
-            <Button
-              variant="outline"
-              className="flex items-center border-border/50 bg-card/20 text-foreground hover:bg-card/30"
+    <PageShell ambientTone="lifted" containerClassName="max-w-4xl py-5 sm:py-8">
+      <PageHeader
+        title={`${talent.first_name} ${talent.last_name}`}
+        subtitle={
+          displayLocation
+            ? displayLocation
+            : "TOTL talent profile — book through the platform."
+        }
+        breadcrumbs={
+          <>
+            <Link
+              href={PATHS.HOME}
+              className="transition-colors hover:text-[var(--oklch-text-primary)]"
             >
+              Home
+            </Link>
+            <span className="text-[var(--oklch-text-tertiary)]">→</span>
+            <span className="text-[var(--oklch-text-secondary)]">Talent</span>
+          </>
+        }
+        actions={
+          <Button variant="outline" size="sm" asChild>
+            <Link href={PATHS.HOME} className="inline-flex items-center">
               <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Home
-            </Button>
-          </Link>
+              Back to home
+            </Link>
+          </Button>
+        }
+        className="mb-6 sm:mb-8"
+      />
+
+      <div className="overflow-hidden rounded-xl border border-white/10 shadow-lg panel-frosted card-backlit">
+        <div className="relative aspect-16-9 sm:aspect-3-4 md:aspect-16-9 lg:h-96">
+          <SafeImage
+            src={
+              talent.portfolio_url &&
+              !talent.portfolio_url.includes("youtube.com") &&
+              !talent.portfolio_url.includes("youtu.be")
+                ? talent.portfolio_url
+                : "https://picsum.photos/800/400"
+            }
+            alt={`${talent.first_name} ${talent.last_name}`}
+            fill
+            className="object-cover"
+            context="talent-profile-header"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" aria-hidden />
         </div>
 
-        <div className="max-w-4xl mx-auto">
-          <div className="overflow-hidden rounded-xl border border-border/40 shadow-lg panel-frosted card-backlit">
-            {/* Header Section */}
-            <div className="relative aspect-16-9 sm:aspect-3-4 md:aspect-16-9 lg:h-96">
-              <SafeImage
-                src={
-                  talent.portfolio_url &&
-                  !talent.portfolio_url.includes("youtube.com") &&
-                  !talent.portfolio_url.includes("youtu.be")
-                    ? talent.portfolio_url
-                    : "https://picsum.photos/800/400"
-                }
-                alt={`${talent.first_name} ${talent.last_name}`}
-                fill
-                className="object-cover"
-                context="talent-profile-header"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent"></div>
-              <div className="absolute bottom-4 left-4 right-4 sm:bottom-6 sm:left-6 sm:right-6">
-                <h1 className="text-white text-2xl sm:text-3xl md:text-4xl font-bold mb-2 line-clamp-2">
-                  {talent.first_name} {talent.last_name}
-                </h1>
-                {talent.location && (
-                  <div className="flex items-center text-gray-300 text-sm sm:text-base">
-                    <MapPin className="mr-2 h-3 w-3 sm:h-4 sm:w-4 flex-shrink-0" />
-                    <span className="line-clamp-1">{talent.location}</span>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Content Section */}
-            <div className="bg-[var(--oklch-bg)]/92 p-4 sm:p-6 md:p-8">
-              <div className="grid grid-cols-1 gap-6 md:gap-8 lg:grid-cols-3">
-                {/* Main Content */}
-                <div className="lg:col-span-2">
-                  {/* About Section */}
-                  <div className="mb-8">
-                    <h2 className="mb-4 text-2xl font-bold text-foreground">About</h2>
-                    <p className="leading-relaxed text-muted-foreground">
-                      {talent.experience || "No experience details provided."}
-                    </p>
-                  </div>
-
-                  {/* Specialties */}
-                  {(() => {
-                    const specialtiesArray = normalizeToStringArray(talent.specialties);
-                    if (specialtiesArray.length === 0) return null;
-                    return (
-                      <div className="mb-8">
-                        <h2 className="mb-4 text-2xl font-bold text-foreground">Specialties</h2>
-                        <div className="flex flex-wrap gap-2">
-                          {specialtiesArray.map((specialty, index) => (
-                            <span
-                              key={index}
-                              className="rounded-full border border-border/50 bg-card/40 px-3 py-1 text-sm font-medium text-foreground"
-                            >
-                              {specialty}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    );
-                  })()}
-
-                  {/* Languages */}
-                  {(() => {
-                    const languagesArray = normalizeToStringArray(talent.languages);
-                    if (languagesArray.length === 0) return null;
-                    return (
-                      <div className="mb-8">
-                        <h2 className="mb-4 text-2xl font-bold text-foreground">Languages</h2>
-                        <div className="flex flex-wrap gap-2">
-                          {languagesArray.map((language, index) => (
-                            <span
-                              key={index}
-                              className="rounded-full border border-border/50 bg-card/40 px-3 py-1 text-sm font-medium text-foreground"
-                            >
-                              {language}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    );
-                  })()}
+        {quickStats.length > 0 ? (
+          <div className="border-b border-white/10 bg-gradient-to-r from-black/55 via-black/40 to-black/30 px-4 py-4 sm:px-6">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-white/60">
+              At a glance
+            </p>
+            <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-6">
+              {quickStats.map((row) => (
+                <div key={row.label} className="min-w-0">
+                  <dt className="text-[11px] text-white/55">{row.label}</dt>
+                  <dd className="truncate text-sm font-medium text-white">{row.value}</dd>
                 </div>
+              ))}
+            </dl>
+          </div>
+        ) : null}
 
-                {/* Sidebar - Client component handles authentication logic */}
-                <TalentProfileClient talent={talent} />
+        <div className="bg-[var(--oklch-bg)]/92 p-4 sm:p-6 md:p-8">
+          <div className="grid grid-cols-1 gap-6 md:gap-8 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <div className="mb-8">
+                <h2 className="mb-2 text-xl font-bold tracking-tight text-[var(--oklch-text-primary)] sm:text-2xl">
+                  Bio
+                </h2>
+                <p className="text-sm text-[var(--oklch-text-secondary)]">
+                  Narrative from this talent&apos;s TOTL profile.
+                </p>
+                <p className="mt-3 text-sm leading-relaxed text-[var(--oklch-text-secondary)] sm:text-base">
+                  {talent.experience || "No experience details provided."}
+                </p>
               </div>
+
+              {(() => {
+                const specialtiesArray = normalizeToStringArray(talent.specialties);
+                if (specialtiesArray.length === 0) return null;
+                return (
+                  <div className="mb-8">
+                    <h2 className="mb-4 text-xl font-bold tracking-tight text-[var(--oklch-text-primary)] sm:text-2xl">
+                      Specialties
+                    </h2>
+                    <div className="flex flex-wrap gap-2">
+                      {specialtiesArray.map((specialty, index) => (
+                        <span
+                          key={index}
+                          className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sm font-medium text-[var(--oklch-text-primary)]"
+                        >
+                          {specialty}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {(() => {
+                const languagesArray = normalizeToStringArray(talent.languages);
+                if (languagesArray.length === 0) return null;
+                return (
+                  <div className="mb-8">
+                    <h2 className="mb-4 text-xl font-bold tracking-tight text-[var(--oklch-text-primary)] sm:text-2xl">
+                      Languages
+                    </h2>
+                    <div className="flex flex-wrap gap-2">
+                      {languagesArray.map((language, index) => (
+                        <span
+                          key={index}
+                          className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-sm font-medium text-[var(--oklch-text-primary)]"
+                        >
+                          {language}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
             </div>
+
+            <TalentProfileClient talent={talent} />
           </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -45,6 +45,7 @@ All other documentation has been organized into the `docs/` folder with the foll
 | `docs/diagrams/` | Architecture diagrams and visual documentation (`diagrams/README.md`) |
 | `docs/tests/` | Test documentation and matrices (`tests/README.md`) |
 | `docs/plans/` | Design plans and implementation summaries (`plans/README.md`) |
+| `docs/work-orders/` | TOTL backlog queue (`work-orders/README.md`) |
 | `docs/runbooks/` | Operational runbooks (one-off production procedures, data hygiene) |
 | `supabase/diagnostics/` | **SQL-only** read-only audits for ops (e.g. `auth-user-delete-fk-audit.sql` when `auth.admin.deleteUser` fails) |
 | `docs/archive/` | Historical / superseded documentation (`archive/README.md`) |

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -1,6 +1,6 @@
 # TOTL Agency — Documentation Spine (3-Layer Source of Truth)
 
-**Last Updated:** May 3, 2026 — Doc spine refreshed (editorial canopy + branded loading primitives; staleness cues on indices). Source of truth: `features/UI_VISUAL_LANGUAGE.md`, `UI_IMPLEMENTATION_INDEX.md`, `components/layout/*`, `components/ui/*`.
+**Last Updated:** May 5, 2026 — PageShell interior pattern noted for client/admin (`features/UI_VISUAL_LANGUAGE.md`). Source of truth: `features/UI_VISUAL_LANGUAGE.md`, `UI_IMPLEMENTATION_INDEX.md`, `components/layout/*`, `components/ui/*`.
 
 This document defines the **single, strict documentation spine** for TOTL Agency. Everything else is **reference** or **archive**.
 
@@ -164,7 +164,7 @@ All other documentation has been organized into the `docs/` folder with the foll
 - `STATUS_BADGE_SYSTEM.md` - 🎨 **NEW** - Comprehensive status badge system with 25+ variants (Nov 2025)
 - `UI_LAYOUT_CONTRACT.md` - 🎨 **NEW** - Canonical Terminal Kit (PageShell/PageHeader/SectionCard/DataTableShell) + mobile safety rules (Dec 2025)
 - `TOTL_ENHANCEMENT_IMPLEMENTATION_PLAN.md` - 🚀 **NEW** - Comprehensive enhancement roadmap for "sellable for millions" marketplace (Jan 2025)
-- `UI_VISUAL_LANGUAGE.md` - 🎨 **CANONICAL** — Design system + layout shells (**`TotlEditorialSection`**, **`TotlBrandLoading*`**, **`AuthLoadingShell`**) — refreshed May 2026
+- `UI_VISUAL_LANGUAGE.md` - 🎨 **CANONICAL** — Design system + layout shells (**`PageShell`** interior convention, **`TotlEditorialSection`**, **`TotlBrandLoading*`**, **`AuthLoadingShell`**) — refreshed May 2026
 - `BOOKING_FLOW_IMPLEMENTATION.md` - Booking workflow implementation
 - `PORTFOLIO_GALLERY_IMPLEMENTATION.md` - Portfolio gallery (current behavior; see also `contracts/PORTFOLIO_UPLOADS_CONTRACT.md`)
 - `guides/OPPORTUNITY_IMAGE_SPECS.md` - Opportunity cover image dimensions (1200×900 px, 4:3) for flyers

--- a/docs/features/UI_VISUAL_LANGUAGE.md
+++ b/docs/features/UI_VISUAL_LANGUAGE.md
@@ -75,12 +75,22 @@ Use these when composing full-page or section-level structure so surfaces stay c
 - **`TotlAtmosphereShell`** — `components/ui/totl-atmosphere-shell.tsx` — optional full-page atmosphere wrapper (gradients, paths, glow) for marketing-style routes.
 - **`TotlSectionDivider`** — `components/ui/totl-section-divider.tsx` — consistent section transitions between bands.
 - **`PageShell`** — `components/layout/page-shell.tsx` — default route wrapper (`page-ambient`, container width, nav top offset); use `fullBleed` when the page controls its own horizontal layout.
+  - **Authenticated interiors (client / admin):** Prefer **`PageShell`** + role header (**`ClientTerminalHeader`** / **`AdminHeader`**) + inner `container` spacing (`px-4 py-5 sm:px-6 sm:py-8 lg:px-8`) instead of wrapping the page in **`TotlAtmosphereShell`** directly. Set `topPadding={false}` and `fullBleed` when the header handles the fold (matches **`/client/dashboard`**).
 - **`SectionCard`** — `components/layout/section-card.tsx` — canonical frosted panel stack (`panel-frosted` + `card-backlit` + `grain-texture`) for grouped content.
 - **`AuthEntryShell`** — `components/layout/auth-entry-shell.tsx` — full-bleed auth/recovery entry (atmosphere + optional back link + `SectionCard`). Props: `omitBackLink`, `panelClassName` / `panelPaddingClassName` for wider holds (e.g. suspended). Container spacing aligns with `/login` (`py-4 sm:py-6 md:py-8`).
 - **`TotlMarketingLoadingBackdrop`**, **`TotlBrandLoadingRibbon`**, **`TotlBrandLoadingRail`** — `components/ui/totl-brand-loading.tsx` — marketing/root **`loading.tsx`** backdrop (**`TotlAtmosphereShell`** + grain + warm veil lane), branded wordmark block, and slim indeterminate rail (`role="progressbar"`, `aria-busy`; CSS `.totl-brand-loading-rail__bar` in **`app/globals.css`**, toned down under `prefers-reduced-motion`).
 - **`TotlEditorialSection`** — `components/ui/totl-editorial-section.tsx` — section-sized editorial canopy (CSS **`.totl-editorial-canopy`** in **`app/globals.css`**: soft radial washes; opacity-only drift when motion is allowed). Use on marketing and high-traffic list heroes (`/`, `/gigs`).
-- **`AuthLoadingShell`** — `components/layout/auth-loading-shell.tsx` — Paths + vignette wrapper for **`/login`**, signup, and recovery loaders; optionally shows **`TotlBrandLoadingRibbon`** for a consistent auth brand moment.
+- **`AuthLoadingShell`** — `components/layout/auth-loading-shell.tsx` — Paths + vignette wrapper for **`/login`**, **`/choose-role`**, onboarding redirect stub (**`/onboarding/select-account-type`**), signup, and recovery loaders; optional **`ambientTone`** to match the destination `PageShell`; shows **`TotlBrandLoadingRibbon`** for a consistent auth brand moment. **`/onboarding`** loading uses **`TotlBrandLoadingRibbon`** inside **`PageShell`** for continuity into profile setup.
 - **Dashboard loaders:** Pass **`routeRole`** on **`PageShell`** in **`ClientDashboardSkeleton`** / **`TalentDashboardSkeleton`** so `[data-role]` ambient matches terminal routes.
+
+### Auth intent + post-sign-in routing (code contract)
+
+- **`pickSafeReturnUrl`** — `lib/utils/return-url.ts` — after sign-in/callback, the first *safe* internal path among `returnUrl` and `next` wins (avoids dropping intent when providers use `next`).
+- **`decidePostAuthRedirect`** — honors that path once the profile is **routable** (role or resolved `account_type`), including talent/client **role** while `account_type` is briefly `unassigned`.
+### Dashboard + account surfaces (density contract)
+
+- **`/settings`** is the canonical **account & profile** destination: tabs for basics, details, portfolio (talent), and **Account** (password, subscription, sign out). Terminal headers link here with **Account & settings** rather than exposing sign out as a primary dashboard action.
+- Prefer **`PageHeader`** for in-page hierarchy below sticky terminal bars, **`MobileSummaryRow`** for scan-friendly mobile stats, and consistent **`container` + `py-5 sm:py-8`** rhythm on dense dashboards.
 
 ## Mobile UX Guidelines
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,6 +16,7 @@ Plans document **design decisions and implementation approaches** for targeted w
 
 ## Start here
 
+- `TOTL_CATCHUP_ROADMAP.md` — Current execution order for the next TOTL improvement batches
 - `STRIPE_WEBHOOK_ORPHANED_CUSTOMER_PLAN.md` — Design plan for orphaned Stripe webhook events
 - `STRIPE_WEBHOOK_ORPHANED_CUSTOMER_IMPLEMENTATION.md` — Implementation summary for orphaned customer handling
 

--- a/docs/plans/TOTL_CATCHUP_ROADMAP.md
+++ b/docs/plans/TOTL_CATCHUP_ROADMAP.md
@@ -1,0 +1,167 @@
+# TOTL Catch-up Roadmap
+
+**Last updated:** May 5, 2026
+
+This is the current execution order for the next TOTL improvement batches.
+Use it with `PROJECT_STATUS_REPORT.md` for live priorities and the specific `docs/work-orders/*.md` files for Cursor prompts.
+
+---
+
+## Product goal
+
+TOTL should feel like a polished talent booking platform end-to-end, not just a functional marketplace.
+
+What to borrow from the better work in the other repos:
+- **ViZb** for lighter, more intentional app shells, loading polish, and cleaner editorials
+- **MMVA** for session-aware auth flows, settings/account structure, and clearer dashboard entry
+- **Both** for better loading states, clearer hierarchy, and route intent that feels like a real product
+
+What to keep from TOTL:
+- premium agency tone
+- talent/client workflow clarity
+- strong booking and opportunity infrastructure
+- production-safe Supabase-first architecture
+
+---
+
+## Product principles
+
+1. **One clean entry path**
+   - auth should feel like entering the product, not bouncing between marketing and app shells
+
+2. **One readable interior**
+   - app surfaces should feel lighter, clearer, and more intentional
+
+3. **Ship one slice fully**
+   - each batch should end with docs updated, verified, and ready to hand off
+
+4. **Prefer existing primitives**
+   - reuse `TotlBrandLoading*`, `TotlEditorialSection`, `PageShell`, `PageHeader`, `AdminHeader`, `ClientTerminalHeader`, `MobileSummaryRow`, and `DataTableShell` where they fit
+
+---
+
+## Roadmap
+
+### 1. Public entry funnel + loading-state cohesion
+
+**Why this first:** the first impression still needs to feel more coherent and app-like.
+
+**Deliverables:**
+- cleaner public/home → auth → role flow
+- better loading shell consistency
+- fewer jarring transitions between marketing and app interior
+- reuse the branded loading primitives already in the codebase
+
+**Definition of done:**
+- the first click path feels deliberate
+- loaders appear instantly and consistently
+- public entry no longer feels like a rough edge
+
+**Current work order:** `docs/work-orders/TOTL_PUBLIC_ENTRY_AND_LOADING_COHESION_WORK_ORDER.md`
+
+---
+
+### 2. Auth session handoff + role redirects
+
+**Why this is next:** auth should preserve intent and land people in the right place every time.
+
+**Deliverables:**
+- callback/session handoff cleanup
+- role-aware redirect behavior
+- less ambiguity around sign-in, reset, and onboarding entry
+- clear fallback states when profile/role data is missing
+
+**Definition of done:**
+- signed-in users land where they expected
+- auth no longer feels flaky or circular
+- role routing is easy to reason about
+
+**Current work order:** `docs/work-orders/TOTL_AUTH_SESSION_HANDOFF_WORK_ORDER.md`
+
+---
+
+### 3. Dashboard density + settings/account rebuild
+
+**Why this is next:** client/talent/admin interiors should feel like real app surfaces, not placeholder panels.
+
+**Deliverables:**
+- better hierarchy and spacing in dashboards
+- proper settings/account destinations
+- clearer admin/client/talent headers
+- more readable cards, tables, and summaries
+
+**Definition of done:**
+- the app interior feels calm and legible
+- account management feels like a normal settings experience
+- dense surfaces are easier to scan on mobile and desktop
+
+**Current work order:** `docs/work-orders/TOTL_DASHBOARD_DENSITY_AND_SETTINGS_WORK_ORDER.md`
+
+---
+
+### 4. Patreon + notifications + booking resilience
+
+**Why this is next:** the recurring pain points should be explainable and recoverable.
+
+**Deliverables:**
+- Patreon connection and entitlement sync clarity
+- notifications button / panel reliability
+- booking reminder and notification surfaces that behave
+- safer failure copy and operator visibility
+
+**Definition of done:**
+- Patreon issues are understandable and recoverable
+- notification UI works reliably
+- booking/reminder flows do not feel fragile
+
+**Current work order:** `docs/work-orders/TOTL_PATREON_AND_NOTIFICATION_RESILIENCE_WORK_ORDER.md`
+
+---
+
+### 5. Discovery, opportunity, and comp-card polish
+
+**Why this is next:** the marketplace should feel richer once the shell is stable.
+
+**Deliverables:**
+- sharper gig/opportunity discovery
+- better filters and cards
+- follow-through on collab / comp-card / provenance work
+- smoother talent profile depth and presentation
+
+**Definition of done:**
+- opportunities are easier to scan and act on
+- talent profiles feel more like digital comp cards
+- the experience feels more complete
+
+**Current work order:** `docs/work-orders/TOTL_DISCOVERY_AND_COMP_CARD_POLISH_WORK_ORDER.md`
+
+---
+
+### 6. Visual style alignment / shared primitives audit
+
+**Why this is still useful:** small visual inconsistencies accumulate quickly across a product this size.
+
+**Deliverables:**
+- route-by-route visual cleanup
+- consistent use of shared primitives
+- mobile density cleanup where needed
+- alignment between public, client, talent, and admin interiors
+
+**Definition of done:**
+- the product feels like one system
+- shared primitives are actually doing the work
+- the app feels premium without extra noise
+
+**Current work order:** `docs/work-orders/TOTL_VISUAL_STYLE_ALIGNMENT_WORK_ORDER.md`
+
+---
+
+## Cursor execution rule
+
+Work top to bottom.
+Do not start the next batch until the current one is done, verified, and documented.
+
+After each batch:
+- update the relevant docs
+- verify the implementation
+- leave the repo in a shippable state

--- a/docs/work-orders/README.md
+++ b/docs/work-orders/README.md
@@ -1,0 +1,20 @@
+# TOTL Work Orders
+
+Use this folder as the current execution queue.
+
+Start here:
+- `docs/plans/TOTL_CATCHUP_ROADMAP.md`
+- `PROJECT_STATUS_REPORT.md`
+
+Work order order:
+1. `TOTL_PUBLIC_ENTRY_AND_LOADING_COHESION_WORK_ORDER.md`
+2. `TOTL_AUTH_SESSION_HANDOFF_WORK_ORDER.md`
+3. `TOTL_DASHBOARD_DENSITY_AND_SETTINGS_WORK_ORDER.md`
+4. `TOTL_PATREON_AND_NOTIFICATION_RESILIENCE_WORK_ORDER.md`
+5. `TOTL_DISCOVERY_AND_COMP_CARD_POLISH_WORK_ORDER.md`
+6. `TOTL_VISUAL_STYLE_ALIGNMENT_WORK_ORDER.md`
+
+Rules:
+- Work top to bottom.
+- Finish one batch, verify it, then move to the next.
+- Keep docs and code aligned after each batch.

--- a/docs/work-orders/TOTL_AUTH_SESSION_HANDOFF_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_AUTH_SESSION_HANDOFF_WORK_ORDER.md
@@ -1,0 +1,51 @@
+# TOTL Auth Session Handoff + Role Redirect Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make auth behave like a reliable app entry point.
+
+This batch is for callback handling, preserved intent, and role-aware redirects.
+
+## Product decision
+Protect the intended destination and make the fallback state obvious when profile or role data is missing.
+
+## What to build
+
+### Callback and session handoff
+- Verify the callback path exchanges session state cleanly.
+- Preserve the `next` destination when it is valid.
+- Handle missing or stale auth states explicitly.
+
+### Role-aware entry
+- Viewer entry should land in the right viewer surface.
+- Client and talent entry should land in the right shell.
+- Admin entry should land in the right operator workspace.
+
+### Fallback states
+- If role/profile data is missing or ambiguous, show a clear setup/onboarding path.
+- Do not silently bounce users back into the wrong surface.
+
+## Implementation guidance
+- Inspect auth routes, middleware, callback routes, and role resolution helpers.
+- Reuse the existing auth architecture instead of building a second one.
+- Do not change booking or opportunity logic in this batch.
+- Keep the current security model intact.
+
+## Acceptance criteria
+- Auth preserves intent.
+- Users land in the expected app surface.
+- Missing profile / role states are clear, not mysterious.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect auth login/callback/redirect helpers.
+2. Fix the destination logic.
+3. Tighten the fallback copy and role handling.
+4. Verify login and logout flows.
+5. Update docs if route intent changes.
+
+## Notes
+- This is the batch where auth stops feeling like a detour.
+- Keep the UX calm and explicit.

--- a/docs/work-orders/TOTL_DASHBOARD_DENSITY_AND_SETTINGS_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_DASHBOARD_DENSITY_AND_SETTINGS_WORK_ORDER.md
@@ -1,0 +1,51 @@
+# TOTL Dashboard Density + Settings Rebuild Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make the authenticated interiors feel like real product surfaces, not placeholder dashboards.
+
+This batch focuses on client, talent, and admin density, plus a proper settings/account destination.
+
+## Product decision
+Use the existing shared layout primitives and the better shell patterns from the other apps to raise readability and hierarchy.
+
+## What to build
+
+### Dashboard interiors
+- Improve spacing, hierarchy, and scanability.
+- Make dense surfaces easier to read on desktop and mobile.
+- Use the right shared primitives for summaries, cards, and tables.
+
+### Settings/account
+- Put account/profile actions in a proper settings surface.
+- Make sign-out and account management feel normal and obvious.
+- Avoid hiding account behavior in the header alone.
+
+### Admin/client/talent shells
+- Keep the terminal headers and page shells consistent.
+- Reuse `AdminHeader`, `ClientTerminalHeader`, `PageShell`, `PageHeader`, `MobileSummaryRow`, and `DataTableShell` where appropriate.
+
+## Implementation guidance
+- Inspect client dashboard, talent dashboard, admin sections, profile, and settings surfaces.
+- Borrow the app-interior structure discipline from ViZb/MMVA.
+- Do not change auth rules or business logic unless needed for the shell.
+- Keep mobile readable.
+
+## Acceptance criteria
+- The dashboard feels calmer and more legible.
+- Settings/account feels like a normal place to land.
+- Shared primitives are used consistently.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect the dashboard and settings entry points.
+2. Normalize the shell and density primitives.
+3. Move account/profile actions into settings if needed.
+4. Verify mobile and desktop readability.
+5. Update docs if route intent changes.
+
+## Notes
+- This is the batch that makes the app interior feel intentional.
+- Use the more readable shell language from the other repos, but keep TOTL premium.

--- a/docs/work-orders/TOTL_DISCOVERY_AND_COMP_CARD_POLISH_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_DISCOVERY_AND_COMP_CARD_POLISH_WORK_ORDER.md
@@ -1,0 +1,51 @@
+# TOTL Discovery + Comp-Card Polish Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make discovery and profile surfaces feel more complete and easier to use.
+
+This batch builds on the opportunity / comp-card work already in motion and tightens the discovery experience around it.
+
+## Product decision
+Keep the existing opportunity model, then make the surfaces that feed it feel more premium and useful.
+
+## What to build
+
+### Discovery
+- Improve opportunity browsing and filtering.
+- Make cards easier to scan.
+- Surface the most useful action paths more clearly.
+
+### Comp-card / profile depth
+- Continue the comp-card style profile evolution.
+- Make the talent profile feel more like a real agency card.
+- Keep the guidance and profile data structured cleanly.
+
+### Collaboration and provenance
+- If the collab/provenance work still needs polish, keep it server-validated and obvious in the UI.
+- Preserve the current admin visibility where implemented.
+
+## Implementation guidance
+- Inspect gig/opportunity routes, talent profile surfaces, and the existing opportunity expansion work order.
+- Reuse the current fields, cards, and status patterns.
+- Do not invent a second discovery system.
+- Keep the feature usable on mobile.
+
+## Acceptance criteria
+- Discovery is easier to scan.
+- Profiles feel more like digital comp cards.
+- Collab/provenance details stay clear.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect the current opportunity and profile surfaces.
+2. Tighten discovery cards and filters.
+3. Polish comp-card/profile presentation.
+4. Verify the collaboration/provenance flow.
+5. Update docs if any fields or route intent changes.
+
+## Notes
+- This should feel like a sharper creative marketplace, not just a database of jobs.
+- Keep the premium tone.

--- a/docs/work-orders/TOTL_PATREON_AND_NOTIFICATION_RESILIENCE_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_PATREON_AND_NOTIFICATION_RESILIENCE_WORK_ORDER.md
@@ -1,0 +1,53 @@
+# TOTL Patreon + Notification Resilience Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make Patreon, notifications, and booking reminders reliable and explainable.
+
+This batch addresses the current Patreon pain point and the notification/booking paths that users and admins depend on.
+
+## Product decision
+Treat Patreon and notification state as server truth and make failures visible in a calm, supportable way.
+
+## What to build
+
+### Patreon connection
+- Clean up the Patreon connect and callback flow.
+- Preserve the intended redirect path.
+- Explain failed or broken states clearly.
+
+### Entitlement sync
+- Verify entitlement state against the latest server-side truth.
+- Make resync / webhook behavior debuggable.
+- Avoid client-trusted entitlement logic.
+
+### Notifications and reminders
+- Fix the broken Notifications UI path.
+- Make new member / booking notification signals reliable.
+- Keep the reminder flow and operator visibility working.
+
+## Implementation guidance
+- Inspect Patreon auth, webhook, entitlement, and notification routes.
+- Reuse the existing notification infrastructure and safe logging patterns.
+- Do not broaden the product into new perks without confirmation.
+- Keep the flow production-safe.
+
+## Acceptance criteria
+- Patreon connect works or fails clearly.
+- Entitlement state is understandable.
+- Notifications UI works.
+- Booking reminders / signals are debuggable.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect Patreon callback and sync flow.
+2. Tighten failure handling and user-visible state.
+3. Fix notification entry points.
+4. Verify reminder / operator visibility behavior.
+5. Update docs if operator steps change.
+
+## Notes
+- This is the batch that removes the current known pain.
+- Keep the copy explicit and the failure states calm.

--- a/docs/work-orders/TOTL_PUBLIC_ENTRY_AND_LOADING_COHESION_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_PUBLIC_ENTRY_AND_LOADING_COHESION_WORK_ORDER.md
@@ -1,0 +1,52 @@
+# TOTL Public Entry + Loading-State Cohesion Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make the first impression feel like a clean app entry, not a rough handoff between marketing and product.
+
+This batch focuses on the public entry path, the first authenticated transition, and the loading experience.
+
+## Product decision
+Use the best shell and loading ideas already present in the codebase, including the branded loading patterns and editorial canopy treatments, and tighten the entry path so it feels deliberate.
+
+## What to build
+
+### Public entry
+- Clean up the public/home entry path so it clearly points into the product.
+- Make the first click path feel intentional.
+- Reduce friction between marketing entry and app interior.
+
+### Loading cohesion
+- Use consistent branded loading states across the touched routes.
+- Prefer the existing `TotlBrandLoading*` and related shell primitives where possible.
+- Avoid generic blank or jumpy waits.
+
+### Entry handoff
+- Make sure the first signed-in transition feels like entering the app.
+- Keep the route intent obvious.
+- Avoid bouncey or ambiguous redirects.
+
+## Implementation guidance
+- Inspect the current home, login, choose-role, onboarding, and top-level loading routes.
+- Reuse the existing loading and section primitives instead of inventing new ones.
+- Keep the diff minimal.
+- Do not change booking, gig, or dashboard business logic in this batch.
+
+## Acceptance criteria
+- The first click path feels clean.
+- Loading states are consistent and branded.
+- Users do not feel bounced between marketing and product.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect current public entry and loading routes.
+2. Standardize the loading experience on the touched routes.
+3. Tighten the public entry copy and handoff.
+4. Verify the route transitions.
+5. Update docs if any route intent changes.
+
+## Notes
+- This is about feel and continuity as much as functionality.
+- Borrow the polished shell language from the other repos, but keep TOTL’s premium agency tone.

--- a/docs/work-orders/TOTL_VISUAL_STYLE_ALIGNMENT_WORK_ORDER.md
+++ b/docs/work-orders/TOTL_VISUAL_STYLE_ALIGNMENT_WORK_ORDER.md
@@ -1,0 +1,51 @@
+# TOTL Visual Style Alignment Work Order
+
+Related roadmap: `docs/plans/TOTL_CATCHUP_ROADMAP.md`.
+Execution companion: `PROJECT_STATUS_REPORT.md`.
+
+## Goal
+Make the app feel like one coherent system.
+
+This batch is the visual consistency pass across public, client, talent, and admin surfaces.
+
+## Product decision
+Use the same shell/primitives discipline everywhere and eliminate drift between routes.
+
+## What to build
+
+### Shared primitives
+- Audit repeated cards, shells, headers, and table layouts.
+- Reuse the canonical primitives instead of ad hoc wrappers.
+- Prefer the loading and editorial patterns already in the codebase.
+
+### Route consistency
+- Check public, client, talent, and admin interiors for style drift.
+- Tighten spacing, contrast, and hover states where needed.
+- Keep the look premium but restrained.
+
+### Mobile density
+- Make dense surfaces easier to scan on smaller screens.
+- Reduce overstacked panels or awkwardly dark areas.
+
+## Implementation guidance
+- Inspect the UI primitives, layout wrappers, and route-specific pages.
+- Prefer incremental cleanup over broad redesign.
+- Borrow the strongest shell language from ViZb/MMVA where it improves readability.
+- Do not introduce a new design system.
+
+## Acceptance criteria
+- The product feels like one system.
+- Shared primitives are used consistently.
+- Mobile readability improves.
+- Build passes.
+
+## Suggested implementation order
+1. Inspect the highest-traffic surfaces.
+2. Identify repeated visual drift.
+3. Normalize the primitives and shell usage.
+4. Verify mobile and desktop consistency.
+5. Update docs if any canonical primitive changes.
+
+## Notes
+- This is the cleanup pass that keeps the product premium.
+- Small consistency wins matter here.


### PR DESCRIPTION
## What broke

- Client terminal interiors (`/client/applications`, `/client/gigs`, `/client/bookings`) wrapped pages in **`TotlAtmosphereShell`** directly instead of the shared **`PageShell`** pattern used on **`/client/dashboard`**, so atmosphere, spacing, and role metadata drifted between routes.
- Public talent profile (`/talent/[slug]`) used a one-off full-page background wrapper and duplicated the talent name in the hero overlay and in page chrome.
- Admin application detail mounted **`AdminHeader`** outside the same shell stack as the page body and used a bespoke title block instead of **`PageHeader`**.

## Why it broke

- Layout primitives (**`PageShell`**, **`ClientTerminalHeader`**, **`AdminHeader`**, **`PageHeader`**) matured faster than a full route sweep, leaving some high-traffic screens on the lower-level atmosphere wrapper.

## What we changed

- Client list surfaces now use **`PageShell`** (`ambientTone="lifted"`, `routeRole="client"`, `topPadding={false}`, `fullBleed`) with aligned inner `container` padding; applications exposes **`MobileSummaryRow`** on mobile without a collapsed stats disclosure.
- **`/admin/applications/[id]`** uses **`PageShell`** + **`AdminHeader`** + **`PageHeader`**; the RSC page no longer renders the header outside the client shell.
- **`/admin/gigs/success`** uses **`PageShell`** with `routeRole="admin"` and slightly improved narrow-view typography on the invalid-ID state.
- **`/talent/[slug]`** uses **`PageShell`** + **`PageHeader`** (breadcrumbs + back action); hero image remains without duplicating the title; bio/specialties/languages use OKLCH text tokens and tighter mobile heading scale.
- Documentation: status + visual-language note for the PageShell interior convention and index staleness.

**Scope note:** `main...develop` includes **two commits**: catch-up roadmap/work-order docs (`4f9fe54`) and this UI alignment commit (`af6d73e`).

## How we proved it

- `npm run schema:verify:comprehensive` — pass
- `npm run types:check` — pass
- `npm run build` — pass
- `npm run lint` — pass
- Git `pre-commit` (runs guards + `next build`) — pass on `af6d73e`

Manual / staging browser checks were **not** run in this session; recommend a quick smoke on the routes above at mobile widths.

## Docs updated: yes

- `MVP_STATUS_NOTION.md`
- `docs/features/UI_VISUAL_LANGUAGE.md`
- `docs/DOCUMENTATION_INDEX.md`
- (Docs batch only) `docs/plans/TOTL_CATCHUP_ROADMAP.md`, related `docs/work-orders/*`, `docs/DOCUMENTATION_INDEX.md`, `docs/plans/README.md`, `docs/work-orders/README.md`, `PROJECT_STATUS_REPORT.md` — commit `4f9fe54`

## Risk + rollback

**Risk level:** Low (presentation-only in `af6d73e`; no API/schema changes in that commit).

**Rollback plan:** Revert `af6d73e` on `develop` (and optionally `4f9fe54` if the docs batch should not land) or merge then revert the merge commit on `main` if needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily layout/shell refactors and copy/spacing tweaks, with no API, auth, or data model changes. Main risk is unintended visual regressions from swapped wrappers and updated container padding across several high-traffic routes.
> 
> **Overview**
> **Unifies route chrome and spacing** by migrating client terminal pages (`/client/applications`, `/client/gigs`, `/client/bookings`) and admin surfaces (`/admin/applications/[id]`, `/admin/gigs/success`) from direct `TotlAtmosphereShell` usage to the shared `PageShell` pattern (with role metadata, `topPadding={false}`, `fullBleed`, and consistent container padding).
> 
> **Public talent profile (`/talent/[slug]`) is reworked** to use `PageShell` + `PageHeader` (breadcrumbs/back action), remove duplicate hero titling, and add an “At a glance” quick-stats strip plus tightened typography/token usage.
> 
> **Documentation/planning updates** add a PageShell interior convention note and refresh status/index files, plus introduce a `docs/plans/TOTL_CATCHUP_ROADMAP.md` and a set of `docs/work-orders/*` execution queue docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6d73ed87976e67e5509badfda36b4009d9d4a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->